### PR TITLE
업체 등록 API 구현

### DIFF
--- a/src/docs/asciidoc/Store.adoc
+++ b/src/docs/asciidoc/Store.adoc
@@ -15,10 +15,13 @@ endif::[]
 
 === 업체 등록
 
-==== /api/stores
+==== /api/stores/{memberId}
 
 .Request
 include::{snippets}/store/store-register/http-request.adoc[]
+
+include::{snippets}/store/store-register/path-parameters.adoc[]
+
 
 include::{snippets}/store/store-register/request-fields.adoc[]
 
@@ -29,6 +32,8 @@ include::{snippets}/store/store-register/response-fields.adoc[]
 
 .Request Fail - 잘못된 영업 시간
 include::{snippets}/store/store-register-fail-invalid-business-time/http-response.adoc[]
+
+include::{snippets}/store/store-register-fail-invalid-business-time/path-parameters.adoc[]
 
 include::{snippets}/store/store-register-fail-invalid-business-time/response-fields.adoc[]
 

--- a/src/docs/asciidoc/Store.adoc
+++ b/src/docs/asciidoc/Store.adoc
@@ -2,7 +2,7 @@ ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
 
-= REST Docs 메인 서비스 API
+= REST Docs 업체 API
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs

--- a/src/docs/asciidoc/Store.adoc
+++ b/src/docs/asciidoc/Store.adoc
@@ -1,0 +1,79 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+
+= REST Docs 메인 서비스 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[User-API]]
+== Store API
+
+=== 업체 등록
+
+==== /api/stores
+
+.Request
+include::{snippets}/store/store-register/http-request.adoc[]
+
+include::{snippets}/store/store-register/request-fields.adoc[]
+
+.Response
+include::{snippets}/store/store-register/http-response.adoc[]
+
+include::{snippets}/store/store-register/response-fields.adoc[]
+
+.Request Fail - 잘못된 영업 시간
+include::{snippets}/store/store-register-fail-invalid-business-time/http-response.adoc[]
+
+include::{snippets}/store/store-register-fail-invalid-business-time/response-fields.adoc[]
+
+// .Request Fail - 잘못된 데이터 입력
+// include::{snippets}/mainItem/mainItem-create-fail-invalid-value/http-request.adoc[]
+//
+// include::{snippets}/mainItem/mainItem-create-fail-invalid-value/request-fields.adoc[]
+//
+// include::{snippets}/mainItem/mainItem-create-fail-invalid-value/http-response.adoc[]
+//
+// include::{snippets}/mainItem/mainItem-create-fail-invalid-value/response-fields.adoc[]
+
+// === 메인 서비스 전체 조회
+//
+// ==== /api/v1/posts
+//
+// .Request
+// include::{snippets}/mainItem/mainItem-find-all/http-request.adoc[]
+//
+// .Response
+// include::{snippets}/mainItem/mainItem-find-all/http-response.adoc[]
+//
+// include::{snippets}/mainItem/mainItem-find-all/response-fields.adoc[]
+//
+// === 메인 서비스 단건 조회
+//
+// ==== /api/v1/main-items/{id}
+//
+// include::{snippets}/mainItem/mainItem-get-one-by-id/http-request.adoc[]
+// include::{snippets}/mainItem/mainItem-get-one-by-id/path-parameters.adoc[]
+//
+// include::{snippets}/mainItem/mainItem-get-one-by-id/http-response.adoc[]
+// include::{snippets}/mainItem/mainItem-get-one-by-id/response-fields.adoc[]
+// .Request Fail - 존재하지 않는 게시물
+// include::{snippets}/mainItem/mainItem-get-one-by-id-fail-not-found/http-request.adoc[]
+// include::{snippets}/mainItem/mainItem-get-one-by-id-fail-not-found/path-parameters.adoc[]
+// include::{snippets}/mainItem/mainItem-get-one-by-id-fail-not-found/http-response.adoc[]
+// include::{snippets}/mainItem/mainItem-get-one-by-id-fail-not-found/response-fields.adoc[]
+//
+// === 서비스 수정
+//
+// ==== /api/v1/main-items/{id}
+// .Request
+// include::{snippets}/mainItem/mainItem-update/http-request.adoc[]
+// include::{snippets}/mainItem/mainItem-update/path-parameters.adoc[]
+// .Response
+// include::{snippets}/mainItem/mainItem-update/http-response.adoc[]
+// include::{snippets}/mainItem/mainItem-update/response-fields.adoc[]

--- a/src/main/java/com/palpal/dealightbe/domain/address/application/AddressService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/address/application/AddressService.java
@@ -1,0 +1,32 @@
+package com.palpal.dealightbe.domain.address.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.address.domain.Address;
+import com.palpal.dealightbe.domain.address.domain.AddressRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Transactional
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AddressService {
+
+	private final AddressRepository addressRepository;
+
+	public AddressRes register(String name, double x, double y) {
+		Address address = Address.builder()
+			.name(name)
+			.xCoordinate(x)
+			.yCoordinate(y)
+			.build();
+
+		addressRepository.save(address);
+
+		return AddressRes.from(address);
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/address/application/dto/response/AddressRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/address/application/dto/response/AddressRes.java
@@ -12,11 +12,11 @@ public record AddressRes(
 		return new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 	}
 
-	public static Address toAddress(AddressRes addressRes) {
+	public static Address toAddress(String name, double xCoordinate, double yCoordinate) {
 		return Address.builder()
-			.name(addressRes.name)
-			.xCoordinate(addressRes.xCoordinate)
-			.yCoordinate(addressRes.yCoordinate)
+			.name(name)
+			.xCoordinate(xCoordinate)
+			.yCoordinate(yCoordinate)
 			.build();
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/address/application/dto/response/AddressRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/address/application/dto/response/AddressRes.java
@@ -1,0 +1,22 @@
+package com.palpal.dealightbe.domain.address.application.dto.response;
+
+import com.palpal.dealightbe.domain.address.domain.Address;
+
+public record AddressRes(
+	String name,
+	double xCoordinate,
+	double yCoordinate
+) {
+
+	public static AddressRes from(Address address) {
+		return new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
+	}
+
+	public static Address toAddress(AddressRes addressRes) {
+		return Address.builder()
+			.name(addressRes.name)
+			.xCoordinate(addressRes.xCoordinate)
+			.yCoordinate(addressRes.yCoordinate)
+			.build();
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/address/domain/Address.java
+++ b/src/main/java/com/palpal/dealightbe/domain/address/domain/Address.java
@@ -25,12 +25,12 @@ public class Address extends BaseEntity {
 
 	private String name;
 
-	private int xCoordinate;
+	private double xCoordinate;
 
-	private int yCoordinate;
+	private double yCoordinate;
 
 	@Builder
-	public Address(String name, int xCoordinate, int yCoordinate) {
+	public Address(String name, double xCoordinate, double yCoordinate) {
 		this.name = name;
 		this.xCoordinate = xCoordinate;
 		this.yCoordinate = yCoordinate;

--- a/src/main/java/com/palpal/dealightbe/domain/address/domain/AddressRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/address/domain/AddressRepository.java
@@ -1,0 +1,7 @@
+package com.palpal.dealightbe.domain.address.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+
+}

--- a/src/main/java/com/palpal/dealightbe/domain/member/domain/MemberRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/domain/MemberRepository.java
@@ -1,0 +1,6 @@
+package com.palpal.dealightbe.domain.member.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/StoreService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/StoreService.java
@@ -36,7 +36,6 @@ public class StoreService {
 		addressService.register(req.addressName(), req.xCoordinate(), req.yCoordinate());
 
 		Store store = StoreCreateReq.toStore(req);
-
 		store.updateMember(member);
 		storeRepository.save(store);
 

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/StoreService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/StoreService.java
@@ -1,0 +1,45 @@
+package com.palpal.dealightbe.domain.store.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.palpal.dealightbe.domain.address.application.AddressService;
+import com.palpal.dealightbe.domain.member.domain.Member;
+import com.palpal.dealightbe.domain.member.domain.MemberRepository;
+import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoreRes;
+import com.palpal.dealightbe.domain.store.domain.Store;
+import com.palpal.dealightbe.domain.store.domain.StoreRepository;
+import com.palpal.dealightbe.global.error.ErrorCode;
+import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Transactional
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class StoreService {
+
+	private final StoreRepository storeRepository;
+	private final MemberRepository memberRepository;
+	private final AddressService addressService;
+
+	public StoreRes register(Long memberId, StoreCreateReq req) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> {
+				log.warn("GET:READ:NOT_FOUND_MEMBER_BY_ID : {}", memberId);
+				throw new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER);
+			});
+
+		addressService.register(req.addressName(), req.xCoordinate(), req.yCoordinate());
+
+		Store store = StoreCreateReq.toStore(req);
+
+		store.updateMember(member);
+		storeRepository.save(store);
+
+		return StoreRes.from(store);
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/StoreService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/StoreService.java
@@ -7,7 +7,7 @@ import com.palpal.dealightbe.domain.address.application.AddressService;
 import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.domain.member.domain.MemberRepository;
 import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
-import com.palpal.dealightbe.domain.store.application.dto.response.StoreRes;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoreCreateRes;
 import com.palpal.dealightbe.domain.store.domain.Store;
 import com.palpal.dealightbe.domain.store.domain.StoreRepository;
 import com.palpal.dealightbe.global.error.ErrorCode;
@@ -26,7 +26,7 @@ public class StoreService {
 	private final MemberRepository memberRepository;
 	private final AddressService addressService;
 
-	public StoreRes register(Long memberId, StoreCreateReq req) {
+	public StoreCreateRes register(Long memberId, StoreCreateReq req) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> {
 				log.warn("GET:READ:NOT_FOUND_MEMBER_BY_ID : {}", memberId);
@@ -39,6 +39,6 @@ public class StoreService {
 		store.updateMember(member);
 		storeRepository.save(store);
 
-		return StoreRes.from(store);
+		return StoreCreateRes.from(store);
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
@@ -1,0 +1,31 @@
+package com.palpal.dealightbe.domain.store.application.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.store.domain.Store;
+
+public record StoreCreateReq(
+	String storeNumber,
+	String name,
+	String telephone,
+	String addressName,
+	double xCoordinate,
+	double yCoordinate,
+	LocalDateTime openTime,
+	LocalDateTime closeTime,
+	String dayOff
+) {
+
+	public static Store toStore(StoreCreateReq request) {
+		return Store.builder()
+			.storeNumber(request.storeNumber)
+			.name(request.name)
+			.telephone(request.telephone)
+			.address(AddressRes.toAddress(request.addressName, request.xCoordinate, request.yCoordinate))
+			.openTime(request.openTime)
+			.closeTime(request.closeTime)
+			.dayOff(request.dayOff)
+			.build();
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
@@ -11,13 +11,17 @@ import com.palpal.dealightbe.domain.store.domain.Store;
 public record StoreCreateReq(
 	@NotBlank(message = "사업자 등록 번호는 필수 입력값입니다.")
 	String storeNumber,
+
 	@NotBlank(message = "상호명은 필수 입력값입니다.")
 	String name,
+
 	@NotBlank(message = "업체 전화번호는 필수 입력값입니다.")
 	@Pattern(regexp = "\\d+")
 	String telephone,
+
 	@NotBlank(message = "업체 주소는 필수 입력값입니다.")
 	String addressName,
+
 	double xCoordinate,
 	double yCoordinate,
 	LocalTime openTime,

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
@@ -2,13 +2,21 @@ package com.palpal.dealightbe.domain.store.application.dto.request;
 
 import java.time.LocalDateTime;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
 import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
 import com.palpal.dealightbe.domain.store.domain.Store;
 
 public record StoreCreateReq(
+	@NotBlank(message = "사업자 등록 번호는 필수 입력값입니다.")
 	String storeNumber,
+	@NotBlank(message = "상호명은 필수 입력값입니다.")
 	String name,
+	@NotBlank(message = "업체 전화번호는 필수 입력값입니다.")
+	@Pattern(regexp = "\\d+")
 	String telephone,
+	@NotBlank(message = "업체 주소는 필수 입력값입니다.")
 	String addressName,
 	double xCoordinate,
 	double yCoordinate,

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
@@ -1,11 +1,13 @@
 package com.palpal.dealightbe.domain.store.application.dto.request;
 
 import java.time.LocalTime;
+import java.util.Set;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.store.domain.DayOff;
 import com.palpal.dealightbe.domain.store.domain.Store;
 
 public record StoreCreateReq(
@@ -26,7 +28,7 @@ public record StoreCreateReq(
 	double yCoordinate,
 	LocalTime openTime,
 	LocalTime closeTime,
-	String dayOff
+	Set<DayOff> dayOff
 ) {
 
 	public static Store toStore(StoreCreateReq request) {

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/request/StoreCreateReq.java
@@ -1,6 +1,6 @@
 package com.palpal.dealightbe.domain.store.application.dto.request;
 
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
@@ -20,8 +20,8 @@ public record StoreCreateReq(
 	String addressName,
 	double xCoordinate,
 	double yCoordinate,
-	LocalDateTime openTime,
-	LocalDateTime closeTime,
+	LocalTime openTime,
+	LocalTime closeTime,
 	String dayOff
 ) {
 

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreCreateRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreCreateRes.java
@@ -1,9 +1,11 @@
 package com.palpal.dealightbe.domain.store.application.dto.response;
 
 import java.time.LocalTime;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.store.domain.DayOff;
 import com.palpal.dealightbe.domain.store.domain.Store;
 
 public record StoreCreateRes(
@@ -11,16 +13,19 @@ public record StoreCreateRes(
 	String name,
 	String telephone,
 	AddressRes addressRes,
+
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
 	LocalTime openTime,
+
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
 	LocalTime closeTime,
-	String dayOff
+
+	Set<DayOff> dayOff
 ) {
 
 	public static StoreCreateRes from(Store store) {
 		return new StoreCreateRes(
 			store.getStoreNumber(), store.getName(), store.getTelephone(), AddressRes.from(store.getAddress()),
-			store.getOpenTime(), store.getCloseTime(), store.getDayOff());
+			store.getOpenTime(), store.getCloseTime(), store.getDayOffs());
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreCreateRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreCreateRes.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
 import com.palpal.dealightbe.domain.store.domain.Store;
 
-public record StoreRes(
+public record StoreCreateRes(
 	String storeNumber,
 	String name,
 	String telephone,
@@ -18,8 +18,8 @@ public record StoreRes(
 	String dayOff
 ) {
 
-	public static StoreRes from(Store store) {
-		return new StoreRes(
+	public static StoreCreateRes from(Store store) {
+		return new StoreCreateRes(
 			store.getStoreNumber(), store.getName(), store.getTelephone(), AddressRes.from(store.getAddress()),
 			store.getOpenTime(), store.getCloseTime(), store.getDayOff());
 	}

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreRes.java
@@ -1,7 +1,8 @@
 package com.palpal.dealightbe.domain.store.application.dto.response;
 
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
 import com.palpal.dealightbe.domain.store.domain.Store;
 
@@ -10,8 +11,10 @@ public record StoreRes(
 	String name,
 	String telephone,
 	AddressRes addressRes,
-	LocalDateTime openTime,
-	LocalDateTime closeTime,
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+	LocalTime openTime,
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+	LocalTime closeTime,
 	String dayOff
 ) {
 

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreRes.java
@@ -1,0 +1,23 @@
+package com.palpal.dealightbe.domain.store.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.store.domain.Store;
+
+public record StoreRes(
+	String storeNumber,
+	String name,
+	String telephone,
+	AddressRes addressRes,
+	LocalDateTime openTime,
+	LocalDateTime closeTime,
+	String dayOff
+) {
+
+	public static StoreRes from(Store store) {
+		return new StoreRes(
+			store.getStoreNumber(), store.getName(), store.getTelephone(), AddressRes.from(store.getAddress()),
+			store.getOpenTime(), store.getCloseTime(), store.getDayOff());
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/DayOff.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/DayOff.java
@@ -1,0 +1,41 @@
+package com.palpal.dealightbe.domain.store.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palpal.dealightbe.global.error.ErrorCode;
+import com.palpal.dealightbe.global.error.exception.BusinessException;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@AllArgsConstructor
+@Slf4j
+public enum DayOff {
+	MON("월요일"),
+	TUE("화요일"),
+	WED("수요일"),
+	THU("목요일"),
+	FRI("금요일"),
+	SAT("토요일"),
+	SUN("일요일"),
+	NONE("연중 무휴");
+
+	private String name;
+
+	@JsonValue
+	public String getName() {
+		return name;
+	}
+
+	@JsonCreator
+	public static DayOff fromString(String text) {
+		for (DayOff dayOff : DayOff.values()) {
+			if (dayOff.name.equalsIgnoreCase(text)) {
+				return dayOff;
+			}
+		}
+		throw new BusinessException(ErrorCode.NOT_FOUND_DAY_OFF);
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
@@ -14,9 +14,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
-
 import com.palpal.dealightbe.domain.address.domain.Address;
 import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.global.BaseEntity;
@@ -33,8 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 @Entity
 @Table(name = "stores")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Where(clause = "is_deleted = false")
-@SQLDelete(sql = "UPDATE stores SET is_deleted = true WHERE id = ?")
 @Slf4j
 public class Store extends BaseEntity {
 
@@ -67,15 +62,13 @@ public class Store extends BaseEntity {
 
 	private String dayOff;
 
-	private boolean isDeleted = Boolean.FALSE;
-
 	@Builder
 	public Store(Address address, String name, String storeNumber, String telephone, LocalTime openTime, LocalTime closeTime, String dayOff) {
+		validateBusinessTimes(openTime, closeTime);
 		this.address = address;
 		this.name = name;
 		this.storeNumber = storeNumber;
 		this.telephone = telephone;
-		validateBusinessTimes(openTime, closeTime);
 		this.openTime = openTime;
 		this.closeTime = closeTime;
 		this.dayOff = dayOff;
@@ -95,7 +88,7 @@ public class Store extends BaseEntity {
 
 	private void validateBusinessTimes(LocalTime openTime, LocalTime closeTime) {
 		if (closeTime.isBefore(openTime)) {
-			log.warn("INVALID_BUSINESS_TIME : {},{}", openTime, closeTime);
+			log.warn("INVALID_BUSINESS_TIME : openTime => {}, closeTime => {}", openTime, closeTime);
 			throw new BusinessException(ErrorCode.INVALID_BUSINESS_TIME);
 		}
 	}

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
@@ -1,6 +1,6 @@
 package com.palpal.dealightbe.domain.store.domain;
 
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -53,9 +53,9 @@ public class Store extends BaseEntity {
 
 	private String telephone;
 
-	private LocalDateTime openTime;
+	private LocalTime openTime;
 
-	private LocalDateTime closeTime;
+	private LocalTime closeTime;
 
 	private String image;
 
@@ -64,7 +64,7 @@ public class Store extends BaseEntity {
 	private boolean isDeleted = false;
 
 	@Builder
-	public Store(Address address, String name, String storeNumber, String telephone, LocalDateTime openTime, LocalDateTime closeTime, String dayOff) {
+	public Store(Address address, String name, String storeNumber, String telephone, LocalTime openTime, LocalTime closeTime, String dayOff) {
 		this.address = address;
 		this.name = name;
 		this.storeNumber = storeNumber;
@@ -87,7 +87,7 @@ public class Store extends BaseEntity {
 		this.image = image;
 	}
 
-	private void validateBusinessTimes(LocalDateTime openTime, LocalDateTime closeTime) {
+	private void validateBusinessTimes(LocalTime openTime, LocalTime closeTime) {
 		if (closeTime.isBefore(openTime)) {
 			log.warn("INVALID_BUSINESS_TIME : {},{}", openTime, closeTime);
 			throw new BusinessException(ErrorCode.INVALID_BUSINESS_TIME);

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
@@ -45,7 +45,7 @@ public class Store extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private StoreStatus storeStatus = StoreStatus.CLOSED;
 
-	private String storePhoneNumber;
+	private String storeNumber;
 
 	private String telephone;
 
@@ -60,14 +60,21 @@ public class Store extends BaseEntity {
 	private boolean isDeleted = false;
 
 	@Builder
-	public Store(Address address, String ownerName, String name, String ownerPhoneNumber,
-				 String storePhoneNumber, String telephone, LocalDateTime openTime, LocalDateTime closeTime, String dayOff) {
+	public Store(Address address, String name, String storeNumber, String telephone, LocalDateTime openTime, LocalDateTime closeTime, String dayOff) {
 		this.address = address;
 		this.name = name;
-		this.storePhoneNumber = storePhoneNumber;
+		this.storeNumber = storeNumber;
 		this.telephone = telephone;
 		this.openTime = openTime;
 		this.closeTime = closeTime;
 		this.dayOff = dayOff;
+	}
+
+	public void updateMember(Member member) {
+		this.member = member;
+	}
+
+	public void updateAddress(Address address) {
+		this.address = address;
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
@@ -2,6 +2,7 @@ package com.palpal.dealightbe.domain.store.domain;
 
 import java.time.LocalTime;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -12,6 +13,9 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import com.palpal.dealightbe.domain.address.domain.Address;
 import com.palpal.dealightbe.domain.member.domain.Member;
@@ -29,6 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 @Entity
 @Table(name = "stores")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "is_deleted = false")
+@SQLDelete(sql = "UPDATE stores SET is_deleted = true WHERE id = ?")
 @Slf4j
 public class Store extends BaseEntity {
 
@@ -36,11 +42,11 @@ public class Store extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
 	@JoinColumn(name = "address_id")
 	private Address address;
 
@@ -61,7 +67,7 @@ public class Store extends BaseEntity {
 
 	private String dayOff;
 
-	private boolean isDeleted = false;
+	private boolean isDeleted = Boolean.FALSE;
 
 	@Builder
 	public Store(Address address, String name, String storeNumber, String telephone, LocalTime openTime, LocalTime closeTime, String dayOff) {

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
@@ -16,16 +16,20 @@ import javax.persistence.Table;
 import com.palpal.dealightbe.domain.address.domain.Address;
 import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.global.BaseEntity;
+import com.palpal.dealightbe.global.error.ErrorCode;
+import com.palpal.dealightbe.global.error.exception.BusinessException;
 
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Getter
 @Entity
 @Table(name = "stores")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public class Store extends BaseEntity {
 
 	@Id
@@ -65,6 +69,7 @@ public class Store extends BaseEntity {
 		this.name = name;
 		this.storeNumber = storeNumber;
 		this.telephone = telephone;
+		validateBusinessTimes(openTime, closeTime);
 		this.openTime = openTime;
 		this.closeTime = closeTime;
 		this.dayOff = dayOff;
@@ -76,5 +81,16 @@ public class Store extends BaseEntity {
 
 	public void updateAddress(Address address) {
 		this.address = address;
+	}
+
+	public void updateImage(String image) {
+		this.image = image;
+	}
+
+	private void validateBusinessTimes(LocalDateTime openTime, LocalDateTime closeTime) {
+		if (closeTime.isBefore(openTime)) {
+			log.warn("INVALID_BUSINESS_TIME : {},{}", openTime, closeTime);
+			throw new BusinessException(ErrorCode.INVALID_BUSINESS_TIME);
+		}
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
@@ -1,8 +1,11 @@
 package com.palpal.dealightbe.domain.store.domain;
 
 import java.time.LocalTime;
+import java.util.Set;
 
 import javax.persistence.CascadeType;
+import javax.persistence.CollectionTable;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -37,11 +40,11 @@ public class Store extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "address_id")
 	private Address address;
 
@@ -60,10 +63,13 @@ public class Store extends BaseEntity {
 
 	private String image;
 
-	private String dayOff;
+	@ElementCollection(targetClass = DayOff.class)
+	@CollectionTable(name = "store_day_off", joinColumns = @JoinColumn(name = "store_id"))
+	@Enumerated(EnumType.STRING)
+	private Set<DayOff> dayOffs;
 
 	@Builder
-	public Store(Address address, String name, String storeNumber, String telephone, LocalTime openTime, LocalTime closeTime, String dayOff) {
+	public Store(Address address, String name, String storeNumber, String telephone, LocalTime openTime, LocalTime closeTime, Set<DayOff> dayOff) {
 		validateBusinessTimes(openTime, closeTime);
 		this.address = address;
 		this.name = name;
@@ -71,7 +77,7 @@ public class Store extends BaseEntity {
 		this.telephone = telephone;
 		this.openTime = openTime;
 		this.closeTime = closeTime;
-		this.dayOff = dayOff;
+		this.dayOffs = dayOff;
 	}
 
 	public void updateMember(Member member) {

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/Store.java
@@ -93,7 +93,10 @@ public class Store extends BaseEntity {
 	}
 
 	private void validateBusinessTimes(LocalTime openTime, LocalTime closeTime) {
-		if (closeTime.isBefore(openTime)) {
+		if (openTime.isAfter(closeTime)) {
+			if (openTime.isAfter(LocalTime.of(0, 0)) && closeTime.isBefore(LocalTime.of(5, 0))) {
+				return;
+			}
 			log.warn("INVALID_BUSINESS_TIME : openTime => {}, closeTime => {}", openTime, closeTime);
 			throw new BusinessException(ErrorCode.INVALID_BUSINESS_TIME);
 		}

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/StoreRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/StoreRepository.java
@@ -1,0 +1,6 @@
+package com.palpal.dealightbe.domain.store.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.palpal.dealightbe.domain.store.application.StoreService;
 import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
-import com.palpal.dealightbe.domain.store.application.dto.response.StoreRes;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoreCreateRes;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,9 +22,9 @@ public class StoreController {
 	private final StoreService storeService;
 
 	@PostMapping("/{memberId}")
-	public ResponseEntity<StoreRes> register(@PathVariable Long memberId, @RequestBody @Validated StoreCreateReq req) {
-		StoreRes storeRes = storeService.register(memberId, req);
+	public ResponseEntity<StoreCreateRes> register(@PathVariable Long memberId, @RequestBody @Validated StoreCreateReq req) {
+		StoreCreateRes storeCreateRes = storeService.register(memberId, req);
 
-		return ResponseEntity.ok(storeRes);
+		return ResponseEntity.ok(storeCreateRes);
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
@@ -1,0 +1,30 @@
+package com.palpal.dealightbe.domain.store.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.palpal.dealightbe.domain.store.application.StoreService;
+import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoreRes;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/stores")
+public class StoreController {
+
+	private final StoreService storeService;
+
+	@PostMapping("/{memberId}")
+	public ResponseEntity<StoreRes> register(@PathVariable Long memberId, @RequestBody @Validated StoreCreateReq req) {
+		StoreRes storeRes = storeService.register(memberId, req);
+
+		return ResponseEntity.ok(storeRes);
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -10,6 +10,9 @@ public enum ErrorCode {
 	//서버
 	INTERNAL_SERVER_ERROR("S001", "예기치 못한 오류가 발생했습니다."),
 
+	//멤버
+	NOT_FOUND_MEMBER("M001", "고객을 찾을 수 없습니다."),
+
 	//공용
 	INVALID_INPUT_VALUE("C001", "잘못된 값을 입력하셨습니다.");
 

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
 	NOT_FOUND_MEMBER("M001", "고객을 찾을 수 없습니다."),
 
 	//업체
-	INVALID_BUSINESS_TIME("ST001", "마감 시간은 오픈 시간보다 이전일 수 없습니다");
+	INVALID_BUSINESS_TIME("ST001", "마감 시간은 오픈 시간보다 이전일 수 없습니다"),
+	NOT_FOUND_DAY_OFF("ST002", "존재하지 않는 휴무일 입니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -10,11 +10,14 @@ public enum ErrorCode {
 	//서버
 	INTERNAL_SERVER_ERROR("S001", "예기치 못한 오류가 발생했습니다."),
 
+	//공용
+	INVALID_INPUT_VALUE("C001", "잘못된 값을 입력하셨습니다."),
+
 	//멤버
 	NOT_FOUND_MEMBER("M001", "고객을 찾을 수 없습니다."),
 
-	//공용
-	INVALID_INPUT_VALUE("C001", "잘못된 값을 입력하셨습니다.");
+	//업체
+	INVALID_BUSINESS_TIME("ST001", "마감 시간은 오픈 시간보다 이전일 수 없습니다");
 
 	private final String code;
 	private final String message;

--- a/src/test/java/com/palpal/dealightbe/domain/address/application/AddressServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/address/application/AddressServiceTest.java
@@ -1,0 +1,54 @@
+package com.palpal.dealightbe.domain.address.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.address.domain.Address;
+import com.palpal.dealightbe.domain.address.domain.AddressRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AddressServiceTest {
+
+	@Mock
+	AddressRepository addressRepository;
+
+	@InjectMocks
+	AddressService addressService;
+
+	@Test
+	@DisplayName("주소 저장 성공 테스트")
+	void registerAddressSuccessTest() throws Exception {
+
+		// given
+		String name = "서울시 강남구";
+		double x = 67.89;
+		double y = 293.2323;
+
+		Address addressToSave = Address.builder()
+			.name(name)
+			.xCoordinate(x)
+			.yCoordinate(y)
+			.build();
+
+		when(addressRepository.save(any(Address.class))).thenReturn(addressToSave);
+
+		// when
+		AddressRes addressRes = addressService.register(name, x, y);
+
+		// then
+		assertNotNull(addressRes);
+		assertEquals(name, addressRes.name());
+		assertEquals(x, addressRes.xCoordinate());
+		assertEquals(y, addressRes.yCoordinate());
+	}
+}

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -21,7 +21,7 @@ import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
 import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.domain.member.domain.MemberRepository;
 import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
-import com.palpal.dealightbe.domain.store.application.dto.response.StoreRes;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoreCreateRes;
 import com.palpal.dealightbe.domain.store.domain.StoreRepository;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
@@ -66,11 +66,11 @@ class StoreServiceTest {
 			.thenReturn(new AddressRes("서울시 강남구", 67.89, 293.2323));
 
 		//when
-		StoreRes storeRes = storeService.register(member.getId(), storeCreateReq);
+		StoreCreateRes storeCreateRes = storeService.register(member.getId(), storeCreateReq);
 
 		//then
-		assertThat(storeRes.name()).isEqualTo(storeCreateReq.name());
-		assertThat(storeRes.addressRes().name()).isEqualTo(storeCreateReq.addressName());
+		assertThat(storeCreateRes.name()).isEqualTo(storeCreateReq.name());
+		assertThat(storeCreateRes.addressRes().name()).isEqualTo(storeCreateReq.addressName());
 	}
 
 	@Test

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -25,6 +25,7 @@ import com.palpal.dealightbe.domain.member.domain.MemberRepository;
 import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
 import com.palpal.dealightbe.domain.store.application.dto.response.StoreRes;
 import com.palpal.dealightbe.domain.store.domain.StoreRepository;
+import com.palpal.dealightbe.global.error.exception.BusinessException;
 import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,7 +76,8 @@ class StoreServiceTest {
 	}
 
 	@Test
-	void registerStoreFailureTest() {
+	@DisplayName("업체 등록 실패 - 존재하지 않는 회원")
+	void registerStoreFailureTest_notFoundMember() {
 		// given
 		LocalDateTime openTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(9, 0));
 		LocalDateTime closeTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 0));
@@ -85,6 +87,25 @@ class StoreServiceTest {
 
 		// when -> then
 		assertThrows(EntityNotFoundException.class, () -> {
+			storeService.register(member.getId(), storeCreateReq);
+		});
+	}
+
+	@Test
+	@DisplayName("업체 등록 실패 - 마감 시간이 오픈 시간 보다 빠른 경우")
+	void registerStoreFailureTest_invalidBusinessHour() {
+		// given
+		LocalDateTime openTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 0));
+		LocalDateTime closeTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(9, 0));
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+
+		when(memberRepository.findById(member.getId()))
+			.thenReturn(Optional.of(member));
+		when(addressService.register(eq("서울시 강남구"), eq(67.89), eq(293.2323)))
+			.thenReturn(new AddressRes("서울시 강남구", 67.89, 293.2323));
+
+		// when -> then
+		assertThrows(BusinessException.class, () -> {
 			storeService.register(member.getId(), storeCreateReq);
 		});
 	}

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -1,0 +1,91 @@
+package com.palpal.dealightbe.domain.store.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.palpal.dealightbe.domain.address.application.AddressService;
+import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.member.domain.Member;
+import com.palpal.dealightbe.domain.member.domain.MemberRepository;
+import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoreRes;
+import com.palpal.dealightbe.domain.store.domain.StoreRepository;
+import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+	@Mock
+	private StoreRepository storeRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private AddressService addressService;
+
+	@InjectMocks
+	private StoreService storeService;
+
+	private Member member;
+
+	@BeforeEach
+	void setUp() {
+		member = Member.builder()
+			.nickName("홍섭")
+			.realName("이홍섭")
+			.phoneNumber("010010101")
+			.build();
+	}
+
+	@DisplayName("업체 등록 성공 테스트")
+	@Test
+	void registerStoreSuccessTest() {
+		// given
+		LocalDateTime openTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(9, 0));
+		LocalDateTime closeTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 0));
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+
+		when(memberRepository.findById(member.getId()))
+			.thenReturn(Optional.of(member));
+		when(addressService.register(eq("서울시 강남구"), eq(67.89), eq(293.2323)))
+			.thenReturn(new AddressRes("서울시 강남구", 67.89, 293.2323));
+
+		//when
+		StoreRes storeRes = storeService.register(member.getId(), storeCreateReq);
+
+		//then
+		assertThat(storeRes.name()).isEqualTo(storeCreateReq.name());
+		assertThat(storeRes.addressRes().name()).isEqualTo(storeCreateReq.addressName());
+	}
+
+	@Test
+	void registerStoreFailureTest() {
+		// given
+		LocalDateTime openTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(9, 0));
+		LocalDateTime closeTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 0));
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+
+		when(memberRepository.findById(member.getId())).thenReturn(Optional.empty());
+
+		// when -> then
+		assertThrows(EntityNotFoundException.class, () -> {
+			storeService.register(member.getId(), storeCreateReq);
+		});
+	}
+}

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -54,12 +54,33 @@ class StoreServiceTest {
 			.build();
 	}
 
-	@DisplayName("업체 등록 성공 테스트")
+	@DisplayName("업체 등록 성공")
 	@Test
 	void registerStoreSuccessTest() {
 		// given
 		LocalTime openTime = LocalTime.of(9, 0);
 		LocalTime closeTime = LocalTime.of(23, 0);
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, Set.of(DayOff.MON));
+
+		when(memberRepository.findById(member.getId()))
+			.thenReturn(Optional.of(member));
+		when(addressService.register(eq("서울시 강남구"), eq(67.89), eq(293.2323)))
+			.thenReturn(new AddressRes("서울시 강남구", 67.89, 293.2323));
+
+		//when
+		StoreCreateRes storeCreateRes = storeService.register(member.getId(), storeCreateReq);
+
+		//then
+		assertThat(storeCreateRes.name()).isEqualTo(storeCreateReq.name());
+		assertThat(storeCreateRes.addressRes().name()).isEqualTo(storeCreateReq.addressName());
+	}
+
+	@DisplayName("업체 등록 성공 - 가게가 저녁에 문을 열고 새벽에 닫아도 성공")
+	@Test
+	void registerStoreSuccessTest_businessTime() {
+		// given
+		LocalTime openTime = LocalTime.of(15, 0);
+		LocalTime closeTime = LocalTime.of(02, 0);
 		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, Set.of(DayOff.MON));
 
 		when(memberRepository.findById(member.getId()))
@@ -96,8 +117,8 @@ class StoreServiceTest {
 	@DisplayName("업체 등록 실패 - 마감 시간이 오픈 시간 보다 빠른 경우")
 	void registerStoreFailureTest_invalidBusinessHour() {
 		// given
-		LocalTime openTime = LocalTime.of(23, 0);
-		LocalTime closeTime = LocalTime.of(9, 0);
+		LocalTime openTime = LocalTime.of(15, 0);
+		LocalTime closeTime = LocalTime.of(13, 0);
 		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, Set.of(DayOff.MON));
 
 		when(memberRepository.findById(member.getId()))
@@ -110,4 +131,5 @@ class StoreServiceTest {
 			storeService.register(member.getId(), storeCreateReq);
 		});
 	}
+
 }

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -81,7 +81,8 @@ class StoreServiceTest {
 		LocalTime closeTime = LocalTime.of(23, 0);
 		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
 
-		when(memberRepository.findById(member.getId())).thenReturn(Optional.empty());
+		when(memberRepository.findById(member.getId()))
+			.thenReturn(Optional.empty());
 
 		// when -> then
 		assertThrows(EntityNotFoundException.class, () -> {
@@ -93,7 +94,7 @@ class StoreServiceTest {
 	@DisplayName("업체 등록 실패 - 마감 시간이 오픈 시간 보다 빠른 경우")
 	void registerStoreFailureTest_invalidBusinessHour() {
 		// given
-			LocalTime openTime = LocalTime.of(23, 0);
+		LocalTime openTime = LocalTime.of(23, 0);
 		LocalTime closeTime = LocalTime.of(9, 0);
 		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
 

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalTime;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +23,7 @@ import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.domain.member.domain.MemberRepository;
 import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
 import com.palpal.dealightbe.domain.store.application.dto.response.StoreCreateRes;
+import com.palpal.dealightbe.domain.store.domain.DayOff;
 import com.palpal.dealightbe.domain.store.domain.StoreRepository;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
@@ -58,7 +60,7 @@ class StoreServiceTest {
 		// given
 		LocalTime openTime = LocalTime.of(9, 0);
 		LocalTime closeTime = LocalTime.of(23, 0);
-		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, Set.of(DayOff.MON));
 
 		when(memberRepository.findById(member.getId()))
 			.thenReturn(Optional.of(member));
@@ -79,7 +81,7 @@ class StoreServiceTest {
 		// given
 		LocalTime openTime = LocalTime.of(9, 0);
 		LocalTime closeTime = LocalTime.of(23, 0);
-		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, Set.of(DayOff.MON));
 
 		when(memberRepository.findById(member.getId()))
 			.thenReturn(Optional.empty());
@@ -96,7 +98,7 @@ class StoreServiceTest {
 		// given
 		LocalTime openTime = LocalTime.of(23, 0);
 		LocalTime closeTime = LocalTime.of(9, 0);
-		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, Set.of(DayOff.MON));
 
 		when(memberRepository.findById(member.getId()))
 			.thenReturn(Optional.of(member));

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Optional;
 
@@ -58,8 +56,8 @@ class StoreServiceTest {
 	@Test
 	void registerStoreSuccessTest() {
 		// given
-		LocalDateTime openTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(9, 0));
-		LocalDateTime closeTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 0));
+		LocalTime openTime = LocalTime.of(9, 0);
+		LocalTime closeTime = LocalTime.of(23, 0);
 		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
 
 		when(memberRepository.findById(member.getId()))
@@ -79,8 +77,8 @@ class StoreServiceTest {
 	@DisplayName("업체 등록 실패 - 존재하지 않는 회원")
 	void registerStoreFailureTest_notFoundMember() {
 		// given
-		LocalDateTime openTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(9, 0));
-		LocalDateTime closeTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 0));
+		LocalTime openTime = LocalTime.of(9, 0);
+		LocalTime closeTime = LocalTime.of(23, 0);
 		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
 
 		when(memberRepository.findById(member.getId())).thenReturn(Optional.empty());
@@ -95,8 +93,8 @@ class StoreServiceTest {
 	@DisplayName("업체 등록 실패 - 마감 시간이 오픈 시간 보다 빠른 경우")
 	void registerStoreFailureTest_invalidBusinessHour() {
 		// given
-		LocalDateTime openTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 0));
-		LocalDateTime closeTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(9, 0));
+			LocalTime openTime = LocalTime.of(23, 0);
+		LocalTime closeTime = LocalTime.of(9, 0);
 		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
 
 		when(memberRepository.findById(member.getId()))

--- a/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalTime;
+import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
 import com.palpal.dealightbe.domain.store.application.StoreService;
 import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
 import com.palpal.dealightbe.domain.store.application.dto.response.StoreCreateRes;
+import com.palpal.dealightbe.domain.store.domain.DayOff;
 import com.palpal.dealightbe.global.error.ErrorCode;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 
@@ -59,9 +61,9 @@ class StoreControllerTest {
 		LocalTime openTime = LocalTime.of(9, 0);
 		LocalTime closeTime = LocalTime.of(23, 0);
 
-		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, Set.of(DayOff.MON));
 		AddressRes addressRes = new AddressRes("서울시 강남구", 67.89, 293.2323);
-		StoreCreateRes storeCreateRes = new StoreCreateRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, "월요일");
+		StoreCreateRes storeCreateRes = new StoreCreateRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, Set.of(DayOff.MON));
 
 		given(storeService.register(memberId, storeCreateReq))
 			.willReturn(storeCreateRes);
@@ -77,7 +79,7 @@ class StoreControllerTest {
 			.andExpect(jsonPath("$.addressRes.name").value(storeCreateRes.addressRes().name()))
 			.andExpect(jsonPath("$.openTime").value(storeCreateRes.openTime().toString()))
 			.andExpect(jsonPath("$.closeTime").value(storeCreateRes.closeTime().toString()))
-			.andExpect(jsonPath("$.dayOff").value(storeCreateRes.dayOff()))
+			.andExpect(jsonPath("$.dayOff[0]").value(DayOff.MON.getName()))
 			.andDo(print())
 			.andDo(document("store-register",
 				Preprocessors.preprocessRequest(prettyPrint()),
@@ -116,9 +118,9 @@ class StoreControllerTest {
 		LocalTime openTime = LocalTime.of(23, 0);
 		LocalTime closeTime = LocalTime.of(9, 0);
 
-		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, Set.of(DayOff.MON));
 		AddressRes addressRes = new AddressRes("서울시 강남구", 67.89, 293.2323);
-		StoreCreateRes storeCreateRes = new StoreCreateRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, "월요일");
+		StoreCreateRes storeCreateRes = new StoreCreateRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, Set.of(DayOff.MON));
 
 		given(storeService.register(memberId, storeCreateReq))
 			.willThrow(new BusinessException(ErrorCode.INVALID_BUSINESS_TIME));

--- a/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
@@ -1,0 +1,160 @@
+package com.palpal.dealightbe.domain.store.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.store.application.StoreService;
+import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoreRes;
+import com.palpal.dealightbe.global.error.ErrorCode;
+import com.palpal.dealightbe.global.error.exception.BusinessException;
+
+@WebMvcTest(value = StoreController.class)
+@AutoConfigureRestDocs
+class StoreControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@MockBean
+	StoreService storeService;
+
+	@Test
+	@DisplayName("업체 등록 성공")
+	void registerStoreSuccessTest() throws Exception {
+
+		//given
+		Long memberId = 1L;
+		LocalTime openTime = LocalTime.of(9, 0);
+		LocalTime closeTime = LocalTime.of(23, 0);
+
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+		AddressRes addressRes = new AddressRes("서울시 강남구", 67.89, 293.2323);
+		StoreRes storeRes = new StoreRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, "월요일");
+
+		given(storeService.register(memberId, storeCreateReq))
+			.willReturn(storeRes);
+
+		//when -> then
+		mockMvc.perform(RestDocumentationRequestBuilders.post("/api/stores/{memberId}", memberId)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(storeCreateReq)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.storeNumber").value(storeRes.storeNumber()))
+			.andExpect(jsonPath("$.name").value(storeRes.name()))
+			.andExpect(jsonPath("$.telephone").value(storeRes.telephone()))
+			.andExpect(jsonPath("$.addressRes.name").value(storeRes.addressRes().name()))
+			.andExpect(jsonPath("$.openTime").value(storeRes.openTime().toString()))
+			.andExpect(jsonPath("$.closeTime").value(storeRes.closeTime().toString()))
+			.andExpect(jsonPath("$.dayOff").value(storeRes.dayOff()))
+			.andDo(print())
+			.andDo(document("store-register",
+				Preprocessors.preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				pathParameters(parameterWithName("memberId").description("고객 ID")
+				),
+				requestFields(
+					fieldWithPath("storeNumber").description("사업자 등록 번호"),
+					fieldWithPath("name").description("상호명"),
+					fieldWithPath("telephone").description("업체 전화번호"),
+					fieldWithPath("addressName").description("업체 주소"),
+					fieldWithPath("xCoordinate").description("X 좌표"),
+					fieldWithPath("yCoordinate").description("Y 좌표"),
+					fieldWithPath("openTime").description("오픈 시간"),
+					fieldWithPath("closeTime").description("마감 시간"),
+					fieldWithPath("dayOff").description("휴무일")
+				),
+				responseFields(
+					fieldWithPath("storeNumber").description("사업자 등록 번호"),
+					fieldWithPath("name").description("상호명"),
+					fieldWithPath("telephone").description("업체 전화번호"),
+					subsectionWithPath("addressRes").description("주소 정보"),
+					fieldWithPath("openTime").description("오픈 시간"),
+					fieldWithPath("closeTime").description("마감 시간"),
+					fieldWithPath("dayOff").description("휴무일")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("업체 등록 실패 - 잘못된 영업 시간")
+	void registerStoreFailTest_invalidBusinessTime() throws Exception {
+
+		//given
+		Long memberId = 1L;
+		LocalTime openTime = LocalTime.of(23, 0);
+		LocalTime closeTime = LocalTime.of(9, 0);
+
+		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
+		AddressRes addressRes = new AddressRes("서울시 강남구", 67.89, 293.2323);
+		StoreRes storeRes = new StoreRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, "월요일");
+
+		given(storeService.register(memberId, storeCreateReq))
+			.willThrow(new BusinessException(ErrorCode.INVALID_BUSINESS_TIME));
+
+		//when -> then
+		mockMvc.perform(RestDocumentationRequestBuilders.post("/api/stores/{memberId}", memberId)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(storeCreateReq)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.timestamp").isNotEmpty())
+			.andExpect(jsonPath("$.code").value("ST001"))
+			.andExpect(jsonPath("$.errors").isEmpty())
+			.andExpect(jsonPath("$.message").value("마감 시간은 오픈 시간보다 이전일 수 없습니다"))
+			.andDo(print())
+			.andDo(document("store-register-fail-invalid-business-time",
+				Preprocessors.preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				pathParameters(parameterWithName("memberId").description("고객 ID")
+				),
+				requestFields(
+					fieldWithPath("storeNumber").description("사업자 등록 번호"),
+					fieldWithPath("name").description("상호명"),
+					fieldWithPath("telephone").description("업체 전화번호"),
+					fieldWithPath("addressName").description("업체 주소"),
+					fieldWithPath("xCoordinate").description("X 좌표"),
+					fieldWithPath("yCoordinate").description("Y 좌표"),
+					fieldWithPath("openTime").description("오픈 시간"),
+					fieldWithPath("closeTime").description("마감 시간"),
+					fieldWithPath("dayOff").description("휴무일")
+				),
+				responseFields(
+					fieldWithPath("timestamp").type(STRING).description("예외 시간"),
+					fieldWithPath("code").type(STRING).description("오류 코드"),
+					fieldWithPath("errors").type(ARRAY).description("오류 목록"),
+					fieldWithPath("message").type(STRING).description("오류 메시지")
+				)
+			));
+	}
+}

--- a/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
 import com.palpal.dealightbe.domain.store.application.StoreService;
 import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
-import com.palpal.dealightbe.domain.store.application.dto.response.StoreRes;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoreCreateRes;
 import com.palpal.dealightbe.global.error.ErrorCode;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 
@@ -61,23 +61,23 @@ class StoreControllerTest {
 
 		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
 		AddressRes addressRes = new AddressRes("서울시 강남구", 67.89, 293.2323);
-		StoreRes storeRes = new StoreRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, "월요일");
+		StoreCreateRes storeCreateRes = new StoreCreateRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, "월요일");
 
 		given(storeService.register(memberId, storeCreateReq))
-			.willReturn(storeRes);
+			.willReturn(storeCreateRes);
 
 		//when -> then
 		mockMvc.perform(RestDocumentationRequestBuilders.post("/api/stores/{memberId}", memberId)
 				.contentType(APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(storeCreateReq)))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.storeNumber").value(storeRes.storeNumber()))
-			.andExpect(jsonPath("$.name").value(storeRes.name()))
-			.andExpect(jsonPath("$.telephone").value(storeRes.telephone()))
-			.andExpect(jsonPath("$.addressRes.name").value(storeRes.addressRes().name()))
-			.andExpect(jsonPath("$.openTime").value(storeRes.openTime().toString()))
-			.andExpect(jsonPath("$.closeTime").value(storeRes.closeTime().toString()))
-			.andExpect(jsonPath("$.dayOff").value(storeRes.dayOff()))
+			.andExpect(jsonPath("$.storeNumber").value(storeCreateRes.storeNumber()))
+			.andExpect(jsonPath("$.name").value(storeCreateRes.name()))
+			.andExpect(jsonPath("$.telephone").value(storeCreateRes.telephone()))
+			.andExpect(jsonPath("$.addressRes.name").value(storeCreateRes.addressRes().name()))
+			.andExpect(jsonPath("$.openTime").value(storeCreateRes.openTime().toString()))
+			.andExpect(jsonPath("$.closeTime").value(storeCreateRes.closeTime().toString()))
+			.andExpect(jsonPath("$.dayOff").value(storeCreateRes.dayOff()))
 			.andDo(print())
 			.andDo(document("store-register",
 				Preprocessors.preprocessRequest(prettyPrint()),
@@ -118,7 +118,7 @@ class StoreControllerTest {
 
 		StoreCreateReq storeCreateReq = new StoreCreateReq("888-222-111", "맛짱조개", "01066772291", "서울시 강남구", 67.89, 293.2323, openTime, closeTime, "월요일");
 		AddressRes addressRes = new AddressRes("서울시 강남구", 67.89, 293.2323);
-		StoreRes storeRes = new StoreRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, "월요일");
+		StoreCreateRes storeCreateRes = new StoreCreateRes("888-222-111", "맛짱조개", "01066772291", addressRes, openTime, closeTime, "월요일");
 
 		given(storeService.register(memberId, storeCreateReq))
 			.willThrow(new BusinessException(ErrorCode.INVALID_BUSINESS_TIME));


### PR DESCRIPTION
## 💡 관련 이슈

- close: #34 

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약
- 업체 등록을 위한 주소 저장 로직 구현
- 업체 등록 API 구현

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명

우선 업체를 등록을 위해 별도로 주소를 DB에 저장하는 로직을 구현하였습니다.
또 업체 등록 성공/실패 관련하여 API 구현 및 RestDocs를 작성하였습니다.
서비스 플로우상 회원가입 및 로그인 이후 업체등록 < 버튼을 눌러 업체 정보를 기입하는 것이라 나중에 request header에 토큰등을 이용하여 사용자를 확인할 것이지만 현재 인증/인가쪽 구현이 되지 않아 path parameter로 memberId를 받아서 사용자를 확인하고 있습니다.

## 🌟 리뷰시 요구 사항
- 쉬는날의 경우 요일로 구분을 할 거면 월~금 등을 Enum으로 관리하는게 나을까요?
- 로그인 이후에 '업체를 등록' 하는 플로우로 변경이 되었는데, 가입이 아닌 등록의 개념인데 이렇게 된다면 하나의 Member로 사용하기에 soft Delete를 사용할 필요가 없다고 생각하는데 어떠실까요?
<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->
---
<img width="900" alt="image" src="https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/assets/97447334/cee78bc0-5888-45b4-b335-ac340470f4d4">
<img width="892" alt="image" src="https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/assets/97447334/e5a6fd14-7e2d-4c35-b49b-44653f250f7c">
<img width="902" alt="image" src="https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/assets/97447334/e7db7b2e-fda0-4951-944c-b23cac293f17">
<img width="896" alt="image" src="https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/assets/97447334/3926808c-7ed7-4a2e-9852-e61cb8bf5b23">

<img width="1008" alt="image" src="https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/assets/97447334/15fa5d2d-836c-440c-acbb-be986b42ccc5">
