### PR TITLE
JwtAuthenticationFilter 및 필요한 클래스 구현, 인증객체로부터 ProviderId 값을 추출하는 AOP 구현

### DIFF
--- a/src/main/java/com/palpal/dealightbe/config/SecurityConfig.java
+++ b/src/main/java/com/palpal/dealightbe/config/SecurityConfig.java
@@ -1,15 +1,19 @@
 package com.palpal.dealightbe.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.palpal.dealightbe.domain.auth.domain.Jwt;
 import com.palpal.dealightbe.domain.auth.filter.JwtAuthenticationFilter;
 import com.palpal.dealightbe.domain.auth.presentation.CustomAuthAccessDeniedHandler;
 import com.palpal.dealightbe.domain.auth.presentation.CustomOAuth2AuthenticationSuccessHandler;
@@ -26,7 +30,14 @@ public class SecurityConfig {
 	private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
 	private final CustomOAuth2AuthenticationSuccessHandler customOAuth2AuthenticationSuccessHandler;
 	private final CustomAuthAccessDeniedHandler customAuthAccessDeniedHandler;
-	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final Jwt jwt;
+
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		return web -> web.ignoring()
+			.antMatchers("/h2-console/**")
+			.antMatchers("/**");
+	}
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -47,7 +58,7 @@ public class SecurityConfig {
 			.and()
 			.exceptionHandling().accessDeniedHandler(customAuthAccessDeniedHandler)
 			.and()
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(new JwtAuthenticationFilter(jwt), UsernamePasswordAuthenticationFilter.class)
 			.build();
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/config/SecurityConfig.java
+++ b/src/main/java/com/palpal/dealightbe/config/SecurityConfig.java
@@ -8,24 +8,25 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.palpal.dealightbe.domain.auth.filter.JwtAuthenticationFilter;
+import com.palpal.dealightbe.domain.auth.presentation.CustomAuthAccessDeniedHandler;
 import com.palpal.dealightbe.domain.auth.presentation.CustomOAuth2AuthenticationSuccessHandler;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
 
 	private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
 	private final CustomOAuth2AuthenticationSuccessHandler customOAuth2AuthenticationSuccessHandler;
-
-	public SecurityConfig(AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository,
-		CustomOAuth2AuthenticationSuccessHandler customOAuth2AuthenticationSuccessHandler) {
-		this.authorizationRequestRepository = authorizationRequestRepository;
-		this.customOAuth2AuthenticationSuccessHandler = customOAuth2AuthenticationSuccessHandler;
-	}
+	private final CustomAuthAccessDeniedHandler customAuthAccessDeniedHandler;
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -44,6 +45,9 @@ public class SecurityConfig {
 			.and()
 			.successHandler(customOAuth2AuthenticationSuccessHandler)
 			.and()
+			.exceptionHandling().accessDeniedHandler(customAuthAccessDeniedHandler)
+			.and()
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 			.build();
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/config/WebMvcConfig.java
+++ b/src/main/java/com/palpal/dealightbe/config/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package com.palpal.dealightbe.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private static final long MAX_AGE_SECONDS = 3600;
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry
+			.addMapping("/**")
+			.allowedOrigins("http://localhost:8080", "http://localhost:8081", "http://localhost:3000",
+				"https://dev-dealight.vercel.app")
+			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+			.allowedHeaders("*")
+			.allowCredentials(true)
+			.maxAge(MAX_AGE_SECONDS);
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
@@ -27,8 +27,8 @@ public class AuthService {
 		return authRepository.findByProviderAndProviderId(provider, providerId)
 			.map(member -> {
 				log.info("사용자(provider: {}, providerId: {})의 로그인을 진행합니다.", provider, providerId);
-				String accessToken = jwt.createAccessToken(providerId, member);
-				String refreshToken = jwt.createRefreshToken(providerId, member);
+				String accessToken = jwt.createAccessToken(member);
+				String refreshToken = jwt.createRefreshToken(member);
 
 				return new LoginRes(providerId, accessToken, refreshToken);
 			})

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
@@ -28,7 +28,7 @@ public class AuthService {
 			.map(member -> {
 				log.info("사용자(provider: {}, providerId: {})의 로그인을 진행합니다.", provider, providerId);
 				String accessToken = jwt.createAccessToken(providerId, member);
-				String refreshToken = jwt.createRefreshToken(providerId);
+				String refreshToken = jwt.createRefreshToken(providerId, member);
 
 				return new LoginRes(providerId, accessToken, refreshToken);
 			})

--- a/src/main/java/com/palpal/dealightbe/domain/auth/domain/Jwt.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/domain/Jwt.java
@@ -1,5 +1,7 @@
 package com.palpal.dealightbe.domain.auth.domain;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -7,6 +9,8 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -17,6 +21,7 @@ import com.palpal.dealightbe.domain.member.domain.MemberRole;
 import com.palpal.dealightbe.domain.member.domain.Role;
 import com.palpal.dealightbe.domain.member.domain.RoleType;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
@@ -53,45 +58,81 @@ public class Jwt {
 		log.info("유저({})의 AccessToken 유효시간({})", providerId, expiryDate);
 
 		List<MemberRole> memberRoles = member.getMemberRoles();
-		String roles = memberRoles.stream()
+		String authorities = memberRoles.stream()
 			.map(memberRole -> {
 				Role role = memberRole.getRole();
 				RoleType type = role.getType();
 				return type.name();
 			})
 			.collect(Collectors.joining(","));
-		log.info("유저({})의 권한({})", providerId, roles);
+		log.info("유저({})의 권한({})", providerId, authorities);
 
 		return Jwts.builder()
 			.setSubject(subject)
 			.setIssuer(issuer)
 			.setIssuedAt(now)
 			.setExpiration(expiryDate)
-			.claim("authorities", roles)
+			.claim("Authorities", authorities)
 			.signWith(SignatureAlgorithm.HS256, tokenSecret)
 			.compact();
 	}
 
-	public String createRefreshToken(Long providerId) {
+	public String createRefreshToken(Long providerId, Member member) {
 		String subject = String.valueOf(providerId);
+		log.info("RefreshToken을 생성하는 유저({})", providerId);
+
 		Date now = new Date();
 		Date expiryDate = new Date(now.getTime() + refreshTokenExpiry);
+		log.info("유저({})의 RefreshToken 유효시간({})", providerId, expiryDate);
+
+		List<MemberRole> memberRoles = member.getMemberRoles();
+		String authorities = memberRoles.stream()
+			.map(memberRole -> {
+				Role role = memberRole.getRole();
+				RoleType type = role.getType();
+				return type.name();
+			})
+			.collect(Collectors.joining(","));
+		log.info("유저({})의 권한({})", providerId, authorities);
 
 		return Jwts.builder()
 			.setSubject(subject)
 			.setIssuer(issuer)
 			.setIssuedAt(now)
 			.setExpiration(expiryDate)
+			.claim("Authorities", authorities)
 			.signWith(SignatureAlgorithm.HS256, tokenSecret)
 			.compact();
 	}
 
-	public String parseTokenFromHttpRequest(HttpServletRequest request) {
-		String jwtWithBearer = request.getHeader(HttpHeaders.AUTHORIZATION);
-		if (validateTokenFromRequest(jwtWithBearer)) {
-			return null;
-		}
-		return jwtWithBearer.substring(7);
+	public String getSubject(String jwt) {
+		log.info("Jwt(value: {})로부터 Subject를 가져옵니다...", jwt);
+		Claims claims = Jwts.parserBuilder()
+			.setSigningKey(tokenSecret)
+			.build()
+			.parseClaimsJws(jwt)
+			.getBody();
+
+		String subject = claims.getSubject();
+		log.info("Subject({})를 가져오는데 성공했습니다.", subject);
+		return subject;
+	}
+
+	public Collection<? extends GrantedAuthority> getAuthorities(String jwt) {
+		log.info("Jwt(value: {})로부터 Authority를 가져옵니다...", jwt);
+		Claims claims = Jwts.parserBuilder()
+			.setSigningKey(tokenSecret)
+			.build()
+			.parseClaimsJws(jwt)
+			.getBody();
+
+		String authoritiesFromToken = claims.get("Authorities", String.class);
+		List<SimpleGrantedAuthority> authorities = Arrays.stream(authoritiesFromToken.split(","))
+			.map(SimpleGrantedAuthority::new)
+			.toList();
+		log.info("Authorities({})를 가져오는데 성공했습니다.", authorities);
+
+		return authorities;
 	}
 
 	public boolean validateToken(String jwt) {
@@ -122,25 +163,16 @@ public class Jwt {
 
 	private void validateJwtProperties(JwtConfig jwtConfig) {
 		log.debug("Jwt 설정 값 검증을 시작합니다...");
-
 		log.debug("Issuer : {}", jwtConfig.getIssuer());
 		Assert.hasText(jwtConfig.getIssuer(), "Issuer 정보가 없습니다.");
-
 		log.debug("AccessTokenSecret : {}", jwtConfig.getTokenSecret());
 		Assert.hasText(jwtConfig.getTokenSecret(), "Token Secret 정보가 없습니다.");
-
 		log.debug("AccessTokenExpiry : {}", jwtConfig.getAccessTokenExpiry());
 		Assert.isInstanceOf(Long.class, jwtConfig.getAccessTokenExpiry(),
 			"Access Token 만료시간이 올바르지 않습니다.");
-
 		log.debug("RefreshTokenExpiry : {}", jwtConfig.getRefreshTokenExpiry());
 		Assert.isInstanceOf(Long.class, jwtConfig.getRefreshTokenExpiry(),
 			"Refresh Token 만료시간이 올바르지 않습니다.");
-
 		log.debug("JwtConfig 설정 값 검증에 성공했습니다.");
-	}
-
-	private boolean validateTokenFromRequest(String jwtWithBearer) {
-		return StringUtils.hasText(jwtWithBearer) && jwtWithBearer.startsWith("Bearer ");
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/auth/domain/Jwt.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/domain/Jwt.java
@@ -49,7 +49,8 @@ public class Jwt {
 		log.debug("Jwt 객체 생성에 성공했습니다.");
 	}
 
-	public String createAccessToken(Long providerId, Member member) {
+	public String createAccessToken(Member member) {
+		Long providerId = member.getProviderId();
 		String subject = String.valueOf(providerId);
 		log.info("AccessToken을 생성하는 유저({})", providerId);
 
@@ -62,6 +63,7 @@ public class Jwt {
 			.map(memberRole -> {
 				Role role = memberRole.getRole();
 				RoleType type = role.getType();
+
 				return type.name();
 			})
 			.collect(Collectors.joining(","));
@@ -77,7 +79,8 @@ public class Jwt {
 			.compact();
 	}
 
-	public String createRefreshToken(Long providerId, Member member) {
+	public String createRefreshToken(Member member) {
+		Long providerId = member.getProviderId();
 		String subject = String.valueOf(providerId);
 		log.info("RefreshToken을 생성하는 유저({})", providerId);
 
@@ -90,6 +93,7 @@ public class Jwt {
 			.map(memberRole -> {
 				Role role = memberRole.getRole();
 				RoleType type = role.getType();
+
 				return type.name();
 			})
 			.collect(Collectors.joining(","));

--- a/src/main/java/com/palpal/dealightbe/domain/auth/domain/JwtAuthentication.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/domain/JwtAuthentication.java
@@ -1,0 +1,12 @@
+package com.palpal.dealightbe.domain.auth.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class JwtAuthentication {
+
+	private final String username;
+	private final String token;
+}

--- a/src/main/java/com/palpal/dealightbe/domain/auth/domain/JwtAuthenticationToken.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/domain/JwtAuthenticationToken.java
@@ -1,0 +1,63 @@
+package com.palpal.dealightbe.domain.auth.domain;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final Object principal;
+	private String credentials;
+
+	public JwtAuthenticationToken(String principal, String credentials) {
+		super(null);
+		super.setAuthenticated(false);
+		log.info("JwtAuthenticationToken을 생성합니다...");
+		log.info("Authrities : null, Principal : {}, Credentials : {}, setAuthenticated : false",
+			principal, credentials);
+
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+
+	public JwtAuthenticationToken(Object principal, String credentials,
+		Collection<? extends GrantedAuthority> authorities) {
+		super(authorities);
+		super.setAuthenticated(true);
+		log.info("JwtAuthenticationToken을 생성합니다...");
+		log.info("Authrities : {}, Principal : {}, Credentials : {}, setAuthenticated : true",
+			authorities, principal, credentials);
+
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return credentials;
+	}
+
+	@Override
+	public void setAuthenticated(boolean authenticated) {
+		if (authenticated) {
+			throw new IllegalArgumentException("Authenticated 값을 true로 변경할 수 없습니다.");
+		}
+		super.setAuthenticated(false);
+	}
+
+	@Override
+	public void eraseCredentials() {
+		log.info("JwtAuthenticationToken의 Credential을 제거합니다...");
+		super.eraseCredentials();
+		credentials = null;
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,93 @@
+package com.palpal.dealightbe.domain.auth.filter;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.palpal.dealightbe.domain.auth.domain.Jwt;
+import com.palpal.dealightbe.domain.auth.domain.JwtAuthentication;
+import com.palpal.dealightbe.domain.auth.domain.JwtAuthenticationToken;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final Jwt jwt;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		if (SecurityContextHolder.getContext().getAuthentication() != null) {
+			log.debug("SecurityContextHolder에 이미 인증정보가 존재합니다: {}",
+				SecurityContextHolder.getContext().getAuthentication());
+			filterChain.doFilter(request, response);
+
+			return;
+		}
+
+		String token = parseTokenFromHttpRequest(request);
+		log.info("JwtAuthenticationFilter에서 token({}) 검증을 시작합니다...", token);
+		if (token != null && jwt.validateToken(token)) {
+			try {
+				JwtAuthentication authentication = createJwtAuthentication(token);
+				JwtAuthenticationToken authenticationToken = createJwtAuthenticationToken(request, token,
+					authentication);
+				SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+			} catch (Exception e) {
+				log.warn("Jwt 처리에 실패했습니다: {}", e.getMessage());
+			}
+			filterChain.doFilter(request, response);
+		}
+	}
+
+	private String parseTokenFromHttpRequest(HttpServletRequest request) {
+		log.info("요청 메시지로부터 Authorization 헤더 값을 가져옵니다...");
+		String jwtWithBearer = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (validateTokenFromRequest(jwtWithBearer)) {
+			log.warn("Authorization에 값이 존재하지 않습니다.");
+
+			return null;
+		}
+
+		log.info("Authorization({}) 값을 가져오는데 성공했습니다.", jwtWithBearer);
+		String jwt = jwtWithBearer.substring(7);
+		log.info("Jwt({})를 가져오는데 성공했습니다.", jwt);
+
+		return jwt;
+	}
+
+	private boolean validateTokenFromRequest(String jwtWithBearer) {
+		return StringUtils.hasText(jwtWithBearer) && jwtWithBearer.startsWith("Bearer ");
+	}
+
+	private JwtAuthenticationToken createJwtAuthenticationToken(HttpServletRequest request, String token,
+		JwtAuthentication authentication) {
+		Collection<? extends GrantedAuthority> authorities = jwt.getAuthorities(token);
+		JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authentication, null, authorities);
+		authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+		return authenticationToken;
+	}
+
+	private JwtAuthentication createJwtAuthentication(String token) {
+		String jwtSubject = jwt.getSubject(token);
+
+		return new JwtAuthentication(jwtSubject, token);
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/filter/JwtAuthenticationFilter.java
@@ -37,7 +37,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			log.debug("SecurityContextHolder에 이미 인증정보가 존재합니다: {}",
 				SecurityContextHolder.getContext().getAuthentication());
 			filterChain.doFilter(request, response);
-
 			return;
 		}
 

--- a/src/main/java/com/palpal/dealightbe/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/filter/JwtAuthenticationFilter.java
@@ -25,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final Jwt jwt;

--- a/src/main/java/com/palpal/dealightbe/domain/auth/presentation/CustomAuthAccessDeniedHandler.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/presentation/CustomAuthAccessDeniedHandler.java
@@ -1,0 +1,44 @@
+package com.palpal.dealightbe.domain.auth.presentation;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palpal.dealightbe.global.error.ErrorCode;
+import com.palpal.dealightbe.global.error.ErrorResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CustomAuthAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		Object principal = authentication != null ? authentication.getPrincipal() : null;
+
+		log.warn("권한이 없어 {}의 접근이 거부됐습니다.", principal, accessDeniedException);
+
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.ACCESS_DENIED);
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setContentType("application/json;charset=UTF-8");
+		String accessDenialResponse = objectMapper.writeValueAsString(errorResponse);
+		response.getWriter().write(accessDenialResponse);
+		response.getWriter().flush();
+		response.getWriter().close();
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
@@ -64,4 +64,8 @@ public class Member extends BaseEntity {
 	public void updateAddress(Address address) {
 		this.address = address;
 	}
+
+	public void changeMemberRoles(List<MemberRole> memberRoles) {
+		this.memberRoles = memberRoles;
+	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/member/domain/RoleType.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/domain/RoleType.java
@@ -2,5 +2,5 @@ package com.palpal.dealightbe.domain.member.domain;
 
 public enum RoleType {
 
-	ROLE_MEMBER, ROLE_STORE
+	ROLE_MEMBER, ROLE_STORE, ROLE_ADMIN
 }

--- a/src/main/java/com/palpal/dealightbe/global/aop/ProviderId.java
+++ b/src/main/java/com/palpal/dealightbe/global/aop/ProviderId.java
@@ -1,0 +1,11 @@
+package com.palpal.dealightbe.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ProviderId {
+}

--- a/src/main/java/com/palpal/dealightbe/global/aop/ProviderIdAop.java
+++ b/src/main/java/com/palpal/dealightbe/global/aop/ProviderIdAop.java
@@ -1,0 +1,58 @@
+package com.palpal.dealightbe.global.aop;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.palpal.dealightbe.domain.auth.domain.JwtAuthentication;
+import com.palpal.dealightbe.domain.auth.domain.JwtAuthenticationToken;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Aspect
+@Component
+public class ProviderIdAop {
+
+	private static final String PROVIDER_ID = "providerId";
+
+	@Around("@annotation(ProviderId)")
+	public Object getProviderId(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+		JwtAuthenticationToken authentication = (JwtAuthenticationToken)SecurityContextHolder.getContext()
+			.getAuthentication();
+		JwtAuthentication principal = (JwtAuthentication)authentication.getPrincipal();
+		Long providerId = Long.parseLong(principal.getUsername());
+
+		Object[] modifiedArgs = modifyArgsWithProviderId(providerId, proceedingJoinPoint);
+
+		return proceedingJoinPoint.proceed(modifiedArgs);
+	}
+
+	private Object[] modifyArgsWithProviderId(Long providerId, ProceedingJoinPoint proceedingJoinPoint) {
+		Object[] parameters = proceedingJoinPoint.getArgs();
+		MethodSignature signature = (MethodSignature)proceedingJoinPoint.getSignature();
+		Method method = signature.getMethod();
+		Parameter[] methodParameters = method.getParameters();
+
+		for (int i = 0; i < methodParameters.length; i++) {
+			String parameterName = methodParameters[i].getName();
+			if (parameterName.equals(PROVIDER_ID)) {
+				if (parameters[i] != null) {
+					break;
+				}
+				parameters[i] = providerId;
+			}
+		}
+
+		return parameters;
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -38,6 +38,9 @@ public enum ErrorCode {
 	INVALID_ARRIVAL_TIME("OR002", "예상 도착 시간은 업체 마감 시간 이전이어야 합니다."),
 	INVALID_DEMAND_LENGTH("OR003", "요청 사항은 최대 100자까지 입력할 수 있습니다."),
 
+	//인증, 인가
+	ACCESS_DENIED("AUTH001", "사용자 인증에 실패했습니다."),
+
 	;
 	private final String code;
 	private final String message;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,9 +1,13 @@
 <configuration>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %F, method:%M, %L line : %m%n</pattern>
+            <pattern>%clr(%d{HH:mm:ss.SSS}){magenta} %clr([%thread]){blue} %clr(%-5level){} %clr(%F, method:%M, %L line){cyan} : %m%n
+            </pattern>
         </encoder>
     </appender>
+
     <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/src/test/java/com/palpal/dealightbe/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/application/AuthServiceTest.java
@@ -70,9 +70,9 @@ class AuthServiceTest {
 
 		when(authRepository.findByProviderAndProviderId(member.getProvider(), member.getProviderId()))
 			.thenReturn(Optional.of(member));
-		when(jwt.createAccessToken(member.getProviderId(), member))
+		when(jwt.createAccessToken(member))
 			.thenReturn(mockAccessToken);
-		when(jwt.createRefreshToken(member.getProviderId(), member))
+		when(jwt.createRefreshToken(member))
 			.thenReturn(mockRefreshToken);
 
 		// when

--- a/src/test/java/com/palpal/dealightbe/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/application/AuthServiceTest.java
@@ -72,7 +72,7 @@ class AuthServiceTest {
 			.thenReturn(Optional.of(member));
 		when(jwt.createAccessToken(member.getProviderId(), member))
 			.thenReturn(mockAccessToken);
-		when(jwt.createRefreshToken(member.getProviderId()))
+		when(jwt.createRefreshToken(member.getProviderId(), member))
 			.thenReturn(mockRefreshToken);
 
 		// when

--- a/src/test/java/com/palpal/dealightbe/domain/auth/domain/JwtTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/domain/JwtTest.java
@@ -1,0 +1,232 @@
+package com.palpal.dealightbe.domain.auth.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.security.core.GrantedAuthority;
+
+import com.palpal.dealightbe.config.JwtConfig;
+import com.palpal.dealightbe.domain.member.domain.Member;
+import com.palpal.dealightbe.domain.member.domain.MemberRole;
+import com.palpal.dealightbe.domain.member.domain.Role;
+import com.palpal.dealightbe.domain.member.domain.RoleType;
+
+import io.jsonwebtoken.io.DecodingException;
+import io.jsonwebtoken.security.InvalidKeyException;
+import io.jsonwebtoken.security.WeakKeyException;
+
+class JwtTest {
+
+	JwtConfig jwtConfig;
+	Jwt jwt;
+	List<MemberRole> memberRoles;
+	Member testMember;
+
+	@BeforeEach
+	void setUp() {
+		jwtConfig = new JwtConfig();
+		jwtConfig.setIssuer("test");
+		jwtConfig.setTokenSecret("db3GuBkkt0VD1C2dIcN3eGVa2f0LE7KkXXv8eySXkTVk4c=");
+		jwtConfig.setAccessTokenExpiry(3_600_000L);
+		jwtConfig.setRefreshTokenExpiry(1_296_000_000L);
+		jwt = new Jwt(jwtConfig);
+
+		testMember = Member
+			.builder()
+			.providerId(123L)
+			.provider("test")
+			.build();
+		Role role = new Role(RoleType.ROLE_MEMBER);
+		memberRoles = new ArrayList<>();
+		MemberRole memberRole = new MemberRole(testMember, role);
+		memberRoles.add(memberRole);
+		testMember.changeMemberRoles(memberRoles);
+	}
+
+	@DisplayName("토큰 생성 성공")
+	@Test
+	void createNotEmptyToken() {
+		// when
+		String accessToken = jwt.createAccessToken(testMember);
+		String refreshToken = jwt.createRefreshToken(testMember);
+
+		// then
+		assertThat(accessToken).isNotEmpty();
+		assertThat(refreshToken).isNotEmpty();
+	}
+
+	@DisplayName("토큰의 유효성 검증 성공")
+	@Test
+	void createValidToken() {
+		// when
+		String accessToken = jwt.createAccessToken(testMember);
+		String refreshToken = jwt.createRefreshToken(testMember);
+
+		boolean isValidAccessToken = jwt.validateToken(accessToken);
+		boolean isValidRefreshToken = jwt.validateToken(refreshToken);
+
+		// then
+		assertThat(isValidAccessToken).isTrue();
+		assertThat(isValidRefreshToken).isTrue();
+	}
+
+	@DisplayName("토큰으로부터 가져온 Subject 검증 성공")
+	@Test
+	void parseSubjectFromToken() {
+		// when
+		String accessToken = jwt.createAccessToken(testMember);
+		String refreshToken = jwt.createRefreshToken(testMember);
+
+		String accessTokenSubject = jwt.getSubject(accessToken);
+		String refreshTokenSubject = jwt.getSubject(refreshToken);
+
+		// then
+		assertThat(accessTokenSubject).isEqualTo("123");
+		assertThat(refreshTokenSubject).isEqualTo("123");
+	}
+
+	@DisplayName("토큰으로부터 가져온 Authorities 검증 성공")
+	@Test
+	void parseAuthoritiesFromToken() {
+		// given
+		String ROLE_MEMBER = RoleType.ROLE_MEMBER.name();
+
+		// when
+		String accessToken = jwt.createAccessToken(testMember);
+		String refreshToken = jwt.createRefreshToken(testMember);
+
+		Collection<? extends GrantedAuthority> accessTokenAuthorities = jwt.getAuthorities(accessToken);
+		Collection<? extends GrantedAuthority> refreshTokenAuthorities = jwt.getAuthorities(refreshToken);
+		String accessTokenAuthority = List.copyOf(accessTokenAuthorities)
+			.get(0)
+			.getAuthority();
+		String refreshTokenAuthority = List.copyOf(refreshTokenAuthorities)
+			.get(0)
+			.getAuthority();
+
+		// then
+		assertThat(accessTokenAuthorities).isNotEmpty();
+		assertThat(accessTokenAuthorities.size()).isEqualTo(1);
+		assertThat(accessTokenAuthority).isEqualTo(ROLE_MEMBER);
+
+		assertThat(refreshTokenAuthorities).isNotEmpty();
+		assertThat(refreshTokenAuthorities.size()).isEqualTo(1);
+		assertThat(refreshTokenAuthority).isEqualTo(ROLE_MEMBER);
+	}
+
+	@DisplayName("TokenSecret이 Null이거나 Empty일 경우 Jwt 객체 생성 실패")
+	@NullAndEmptySource
+	@ParameterizedTest
+	void createFailIfTokenSecretIsNullOrEmpty(String invalidTokenSecret) {
+		// given
+		jwtConfig.setTokenSecret(invalidTokenSecret);
+
+		// when -> then
+		assertThatThrownBy(() -> new Jwt(jwtConfig))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("TokenSecret이 잘못된 경우 토큰 생성 실패")
+	@ValueSource(strings = {"12", "123", "fboacn", "fhuireVOFEAWRPK4532DCM"})
+	@ParameterizedTest
+	void createFailIfTokenSecretIsInvalid(String invalidTokenSecret) {
+		// given
+		jwtConfig.setTokenSecret(invalidTokenSecret);
+		Jwt testJwt = new Jwt(jwtConfig);
+
+		// when -> then
+		assertThatThrownBy(() -> testJwt.createAccessToken(testMember))
+			.isInstanceOf(InvalidKeyException.class);
+		assertThatThrownBy(() -> testJwt.createRefreshToken(testMember))
+			.isInstanceOf(InvalidKeyException.class);
+	}
+
+	@DisplayName("TokenSecret의 길이가 1글자 이하일 때, 토큰 생성 실패")
+	@ValueSource(strings = {"!", "1", "a", "A"})
+	@ParameterizedTest
+	void createFailIfSecretLengthIsNotValid(String invalidLengthTokenSecret) {
+		// given
+		jwtConfig.setTokenSecret(invalidLengthTokenSecret);
+		Jwt testJwt = new Jwt(jwtConfig);
+
+		// when -> then
+		assertThatThrownBy(() -> testJwt.createAccessToken(testMember))
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> testJwt.createRefreshToken(testMember))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("8bit 이상의 안전한 TokenSecret(HS256)이 아니라면 토큰 생성에 실패")
+	@ValueSource(strings = {"12", "ac", "AC", "123456789012345678901234", "AbCdEfGhIjKlMnOpQrStUvWx"})
+	@ParameterizedTest
+	void createFailIfSecretIsNotSafe(String notSafeTokenSecret) {
+		// given
+		jwtConfig.setTokenSecret(notSafeTokenSecret);
+		Jwt testJwt = new Jwt(jwtConfig);
+
+		// when -> then
+		assertThatThrownBy(() -> testJwt.createAccessToken(testMember))
+			.isInstanceOf(WeakKeyException.class);
+		assertThatThrownBy(() -> testJwt.createRefreshToken(testMember))
+			.isInstanceOf(WeakKeyException.class);
+	}
+
+	@DisplayName("TokenSecret이 특수문자로만 구성된 경우 토큰 생성 실패")
+	@ValueSource(strings = {"!@#", "@!#$%!@#$%^", "!@#)(*&^%$#@", "#@$%^&*()_*&^%$#@!^&*()"})
+	@ParameterizedTest
+	void createFailIfTokenSecretHasNotValidCharacter(String invalidTokenSecret) {
+		// given
+		jwtConfig.setTokenSecret(invalidTokenSecret);
+		Jwt testJwt = new Jwt(jwtConfig);
+
+		// when -> then
+		assertThatThrownBy(() -> testJwt.createAccessToken(testMember))
+			.isInstanceOf(DecodingException.class);
+		assertThatThrownBy(() -> testJwt.createRefreshToken(testMember))
+			.isInstanceOf(DecodingException.class);
+	}
+
+	@DisplayName("Authority가 없는 경우 토큰 생성 실패")
+	@Test
+	void createFailIfAuthorityIsEmpty() {
+		// given
+		Member invalidMember = Member.builder()
+			.providerId(123L)
+			.build();
+
+		// when -> then
+		assertThatThrownBy(() -> jwt.createAccessToken(invalidMember))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> jwt.createRefreshToken(invalidMember))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@DisplayName("토큰이 유효기간을 넘길 경우 토큰 검증 실패")
+	@Test
+	void validFailIfTokenExceedExpiryTime() {
+		// given
+		jwtConfig.setAccessTokenExpiry(0L);
+		jwtConfig.setRefreshTokenExpiry(0L);
+		Jwt testJwt = new Jwt(jwtConfig);
+
+		// when
+		String expiredAccessToken = testJwt.createAccessToken(testMember);
+		String expiredRefreshToken = testJwt.createRefreshToken(testMember);
+
+		boolean isValidAccessToken = testJwt.validateToken(expiredAccessToken);
+		boolean isValidRefreshToken = testJwt.validateToken(expiredRefreshToken);
+
+		// then
+		assertThat(isValidAccessToken).isFalse();
+		assertThat(isValidRefreshToken).isFalse();
+	}
+}

--- a/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
@@ -50,8 +50,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(value = ItemController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class,
 	OAuth2ClientAutoConfiguration.class}, excludeFilters = {
-	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class,
-		JwtAuthenticationFilter.class})})
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
 @AutoConfigureRestDocs
 class ItemControllerTest {
 

--- a/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
@@ -12,12 +12,16 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.operation.preprocess.Preprocessors;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palpal.dealightbe.config.SecurityConfig;
+import com.palpal.dealightbe.domain.auth.filter.JwtAuthenticationFilter;
 import com.palpal.dealightbe.domain.item.application.ItemService;
 import com.palpal.dealightbe.domain.item.application.dto.request.ItemReq;
 import com.palpal.dealightbe.domain.item.application.dto.response.ItemRes;
@@ -45,7 +49,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(value = ItemController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class,
-	OAuth2ClientAutoConfiguration.class})
+	OAuth2ClientAutoConfiguration.class}, excludeFilters = {
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class,
+		JwtAuthenticationFilter.class})})
 @AutoConfigureRestDocs
 class ItemControllerTest {
 
@@ -87,7 +93,8 @@ class ItemControllerTest {
 	@Test
 	public void itemCreateSuccessTest() throws Exception {
 		//given
-		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage());
+		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(),
+			item.getDescription(), item.getInformation(), item.getImage());
 		ItemRes itemRes = ItemRes.from(item);
 
 		Long memberId = 1L;
@@ -151,7 +158,8 @@ class ItemControllerTest {
 			.store(store)
 			.build();
 
-		ItemReq itemReq = new ItemReq(item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage());
+		ItemReq itemReq = new ItemReq(item2.getName(), item2.getStock(), item2.getDiscountPrice(),
+			item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage());
 		ItemRes itemRes = ItemRes.from(item2);
 
 		Long memberId = 1L;
@@ -208,7 +216,8 @@ class ItemControllerTest {
 
 		Long memberId = 1L;
 
-		when(itemService.create(any(), anyLong())).thenThrow(new BusinessException(ErrorCode.INVALID_ITEM_DISCOUNT_PRICE));
+		when(itemService.create(any(), anyLong())).thenThrow(
+			new BusinessException(ErrorCode.INVALID_ITEM_DISCOUNT_PRICE));
 
 		//when
 		//then
@@ -252,7 +261,8 @@ class ItemControllerTest {
 		Long memberId = 1L;
 
 		ItemReq itemReq = new ItemReq("치즈 떡볶이", 4, 9900, 14000, "치즈 떡볶이 입니다.", "통신사 할인 가능 합니다.", null);
-		ItemRes itemRes = new ItemRes(itemId, 1L, itemReq.name(), itemReq.stock(), itemReq.discountPrice(), itemReq.originalPrice(), itemReq.description(), itemReq.information(), itemReq.image());
+		ItemRes itemRes = new ItemRes(itemId, 1L, itemReq.name(), itemReq.stock(), itemReq.discountPrice(),
+			itemReq.originalPrice(), itemReq.description(), itemReq.information(), itemReq.image());
 
 		when(itemService.update(any(), any(), any())).thenReturn(itemRes);
 
@@ -316,7 +326,8 @@ class ItemControllerTest {
 			.store(store)
 			.build();
 
-		ItemReq itemReq = new ItemReq(item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage());
+		ItemReq itemReq = new ItemReq(item2.getName(), item2.getStock(), item2.getDiscountPrice(),
+			item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage());
 		ItemRes itemRes = ItemRes.from(item2);
 
 		when(itemService.update(any(), any(), any())).thenReturn(itemRes);
@@ -373,7 +384,8 @@ class ItemControllerTest {
 		Long memberId = 1L;
 		Long itemId = 1L;
 
-		when(itemService.update(any(), any(), any())).thenThrow(new BusinessException(ErrorCode.INVALID_ITEM_DISCOUNT_PRICE));
+		when(itemService.update(any(), any(), any())).thenThrow(
+			new BusinessException(ErrorCode.INVALID_ITEM_DISCOUNT_PRICE));
 
 		//when
 		//then

--- a/src/test/java/com/palpal/dealightbe/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/member/presentation/MemberControllerTest.java
@@ -38,8 +38,7 @@ import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
 
 @WebMvcTest(value = MemberController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class,
 	OAuth2ClientAutoConfiguration.class}, excludeFilters = {
-	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class,
-		JwtAuthenticationFilter.class})})
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
 @AutoConfigureRestDocs
 class MemberControllerTest {
 

--- a/src/test/java/com/palpal/dealightbe/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/member/presentation/MemberControllerTest.java
@@ -22,18 +22,24 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palpal.dealightbe.config.SecurityConfig;
 import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.auth.filter.JwtAuthenticationFilter;
 import com.palpal.dealightbe.domain.member.application.MemberService;
 import com.palpal.dealightbe.domain.member.application.dto.response.MemberProfileRes;
 import com.palpal.dealightbe.global.error.ErrorCode;
 import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
 
 @WebMvcTest(value = MemberController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class,
-	OAuth2ClientAutoConfiguration.class})
+	OAuth2ClientAutoConfiguration.class}, excludeFilters = {
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class,
+		JwtAuthenticationFilter.class})})
 @AutoConfigureRestDocs
 class MemberControllerTest {
 

--- a/src/test/java/com/palpal/dealightbe/domain/order/presentation/OrderControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/order/presentation/OrderControllerTest.java
@@ -43,6 +43,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palpal.dealightbe.config.SecurityConfig;
+import com.palpal.dealightbe.domain.auth.filter.JwtAuthenticationFilter;
 import com.palpal.dealightbe.domain.order.application.OrderService;
 import com.palpal.dealightbe.domain.order.application.dto.request.OrderCreateReq;
 import com.palpal.dealightbe.domain.order.application.dto.request.OrderProductReq;
@@ -54,7 +55,8 @@ import com.palpal.dealightbe.domain.order.application.dto.response.OrderRes;
 @AutoConfigureRestDocs
 @WebMvcTest(value = OrderController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class,
 	OAuth2ClientAutoConfiguration.class}, excludeFilters = {
-	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)}
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class,
+		JwtAuthenticationFilter.class})}
 )
 public class OrderControllerTest {
 

--- a/src/test/java/com/palpal/dealightbe/domain/order/presentation/OrderControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/order/presentation/OrderControllerTest.java
@@ -55,9 +55,7 @@ import com.palpal.dealightbe.domain.order.application.dto.response.OrderRes;
 @AutoConfigureRestDocs
 @WebMvcTest(value = OrderController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class,
 	OAuth2ClientAutoConfiguration.class}, excludeFilters = {
-	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class,
-		JwtAuthenticationFilter.class})}
-)
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
 public class OrderControllerTest {
 
 	@Autowired

--- a/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
@@ -28,12 +28,16 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.operation.preprocess.Preprocessors;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palpal.dealightbe.config.SecurityConfig;
 import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.auth.filter.JwtAuthenticationFilter;
 import com.palpal.dealightbe.domain.store.application.StoreService;
 import com.palpal.dealightbe.domain.store.application.dto.request.StoreCreateReq;
 import com.palpal.dealightbe.domain.store.application.dto.request.StoreUpdateReq;
@@ -45,7 +49,9 @@ import com.palpal.dealightbe.global.error.ErrorCode;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 
 @WebMvcTest(value = StoreController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class,
-	OAuth2ClientAutoConfiguration.class})
+	OAuth2ClientAutoConfiguration.class}, excludeFilters = {
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class,
+		JwtAuthenticationFilter.class})})
 @AutoConfigureRestDocs
 class StoreControllerTest {
 
@@ -61,7 +67,6 @@ class StoreControllerTest {
 	@Test
 	@DisplayName("업체 등록 성공")
 	void registerStoreSuccessTest() throws Exception {
-
 		//given
 		Long memberId = 1L;
 		LocalTime openTime = LocalTime.of(9, 0);

--- a/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/presentation/StoreControllerTest.java
@@ -50,8 +50,7 @@ import com.palpal.dealightbe.global.error.exception.BusinessException;
 
 @WebMvcTest(value = StoreController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class,
 	OAuth2ClientAutoConfiguration.class}, excludeFilters = {
-	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class,
-		JwtAuthenticationFilter.class})})
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
 @AutoConfigureRestDocs
 class StoreControllerTest {
 


### PR DESCRIPTION
## 💡 관련 이슈

- close: #51 
- close: #52

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

수행한 작업을 간단히 요약해주세요.

- JwtAuthenticationFilter와 관련 클래스 구현
- ProviderIdAop 클래스 구현, @ProviderId 애노테이션 구현
- WebMvcConfig 구현 및 설정, SecurityConfig 설정 변경 
- Jwt 클래스에 관한 단위 테스트 작성

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명

주요 기능/로직 및 작업 내용에 관해 설명해주세요.

- 요청으로부터 Jwt를 검증해 인증 객체를 만들어내는 JwtAuthenticationFilter를 구현했습니다.
- JwtAuthenticationFilter에서 인증객체를 만들어내기 위해 사용하는 JwtAuthentication과 JwtAuthenticationToken 클래스를 만들었습니다.
- 접근 권한이 없을 경우(403) 에러 메시지를 출력하는 CustomAuthAccessDeniedHandler를 구현했습니다.
- 원활한 구현을 위해 SecurityConfig에서 모든 path에 인증을 요구하지 않도록 변경했습니다.
- CORS 설정을 위한 WebMvcConfig 클래스를 구현했습니다
- 사용자 데이터를 조회하는데 필요한 값인 ProviderId를 토큰에서 쉽게 추출하게 도와주는 AOP인 ProviderAop 및 @ProviderId를 구현했습니다.
- Jwt 클래스에 관한 성공, 실패 단위테스트를 작성했습니다.

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->