### PR TITLE
주문 상태 변경 API

### DIFF
--- a/src/docs/asciidoc/Order.adoc
+++ b/src/docs/asciidoc/Order.adoc
@@ -19,11 +19,13 @@ endif::[]
 
 === 1. 주문 생성
 
-api/orders/{memberProviderId}
+
 
 ==== Request
 
 .Request
+include::{snippets}/order-create-success/path-parameters.adoc[]
+
 include::{snippets}/order-create-success/http-request.adoc[]
 include::{snippets}/order-create-success/request-fields.adoc[]
 
@@ -40,6 +42,8 @@ include::{snippets}/order-create-success/response-fields.adoc[]
 ==== Request
 
 .Request
+include::{snippets}/order-status-update-success/path-parameters.adoc[]
+
 include::{snippets}/order-status-update-success/http-request.adoc[]
 include::{snippets}/order-status-update-success/request-fields.adoc[]
 

--- a/src/docs/asciidoc/Order.adoc
+++ b/src/docs/asciidoc/Order.adoc
@@ -19,14 +19,32 @@ endif::[]
 
 === 1. 주문 생성
 
-/orders/{memberProviderId}
+api/orders/{memberProviderId}
 
 ==== Request
+
 .Request
-include::{snippets}/order-success/http-request.adoc[]
-include::{snippets}/order-success/request-fields.adoc[]
+include::{snippets}/order-create-success/http-request.adoc[]
+include::{snippets}/order-create-success/request-fields.adoc[]
 
 ==== Response
+
 .Response
-include::{snippets}/order-success/http-response.adoc[]
-include::{snippets}/order-success/response-fields.adoc[]
+include::{snippets}/order-create-success/http-response.adoc[]
+include::{snippets}/order-create-success/response-fields.adoc[]
+
+=== 2. 주문 상태 변경
+
+/api/orders/{orderId}/status/{memberProviderId}
+
+==== Request
+
+.Request
+include::{snippets}/order-status-update-success/http-request.adoc[]
+include::{snippets}/order-status-update-success/request-fields.adoc[]
+
+==== Response
+
+.Response
+include::{snippets}/order-status-update-success/http-response.adoc[]
+include::{snippets}/order-status-update-success/response-fields.adoc[]

--- a/src/main/java/com/palpal/dealightbe/domain/order/application/dto/request/OrderStatusUpdateReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/order/application/dto/request/OrderStatusUpdateReq.java
@@ -1,0 +1,9 @@
+package com.palpal.dealightbe.domain.order.application.dto.request;
+
+import javax.validation.constraints.NotBlank;
+
+public record OrderStatusUpdateReq(
+	@NotBlank(message = "변경 후의 주문 상태를 입력해 주세요")
+	String status
+) {
+}

--- a/src/main/java/com/palpal/dealightbe/domain/order/application/dto/response/OrderStatusUpdateRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/order/application/dto/response/OrderStatusUpdateRes.java
@@ -1,0 +1,14 @@
+package com.palpal.dealightbe.domain.order.application.dto.response;
+
+import com.palpal.dealightbe.domain.order.domain.Order;
+
+public record OrderStatusUpdateRes(
+	Long orderId,
+	String status
+) {
+
+	public static OrderStatusUpdateRes from(Order order) {
+		Long orderId = order.getId();
+		return new OrderStatusUpdateRes(orderId, order.getOrderStatus().name());
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/order/domain/Order.java
+++ b/src/main/java/com/palpal/dealightbe/domain/order/domain/Order.java
@@ -82,7 +82,7 @@ public class Order extends BaseEntity {
 		Pair.of("CONFIRMED", "CANCELED")
 	);
 
-	private static final Set<Pair<String, String>> OrderStatusSequenceOfStore = Set.of(
+	private static final Set<Pair<String, String>> orderStatusSequenceOfStore = Set.of(
 		Pair.of("RECEIVED", "CONFIRMED"),
 		Pair.of("RECEIVED", "CANCELED"),
 		Pair.of("CONFIRMED", "COMPLETED"),
@@ -101,7 +101,7 @@ public class Order extends BaseEntity {
 	}
 
 	public void addOrderItems(List<OrderItem> orderItems) {
-		if (orderItems.size() > 5) {
+		if (orderItems.size() > MAX_ORDER_ITEMS) {
 			log.warn("POST:WRITE:EXCEEDED_ORDER_ITEMS : {}", orderItems.size());
 			throw new BusinessException(EXCEEDED_ORDER_ITEMS);
 		}
@@ -176,7 +176,7 @@ public class Order extends BaseEntity {
 			log.warn("PATCH:UPDATE:MEMBER:CANNOT_CHANGE_STATUS:{} -> {}", originalStatus, changedStatus);
 			throw new BusinessException(INVALID_ORDER_STATUS);
 		}
-		if (isStoreOwner(updater) && !OrderStatusSequenceOfStore.contains(inputSequence)) {
+		if (isStoreOwner(updater) && !orderStatusSequenceOfStore.contains(inputSequence)) {
 			log.warn("PATCH:UPDATE:STORE:CANNOT_CHANGE_STATUS:{} -> {}", originalStatus, changedStatus);
 			throw new BusinessException(INVALID_ORDER_STATUS);
 		}

--- a/src/main/java/com/palpal/dealightbe/domain/order/domain/Order.java
+++ b/src/main/java/com/palpal/dealightbe/domain/order/domain/Order.java
@@ -102,6 +102,7 @@ public class Order extends BaseEntity {
 
 	public void addOrderItems(List<OrderItem> orderItems) {
 		if (orderItems.size() > 5) {
+			log.warn("POST:WRITE:EXCEEDED_ORDER_ITEMS : {}", orderItems.size());
 			throw new BusinessException(EXCEEDED_ORDER_ITEMS);
 		}
 
@@ -114,6 +115,8 @@ public class Order extends BaseEntity {
 		Long updaterId = updater.getProviderId();
 
 		if (!(updaterId.equals(storeOwnerId) || updaterId.equals(memberId))) {
+			log.warn("GET:READ:NO_AUTHORITY_TO_UPDATE_ORDER_STATUS: STORE_OWNER{} MEMBER{} UPDATER{}", storeOwnerId,
+				memberId, updaterId);
 			throw new BusinessException(INVALID_ORDER_STATUS_UPDATER);
 		}
 	}
@@ -128,19 +131,21 @@ public class Order extends BaseEntity {
 
 	public void validateStatusRequest(String changedStatus) {
 		if (!OrderStatus.isValidStatus(changedStatus)) {
+			log.warn("GET:READ:NOT_EXISTED_ORDER_STATUS: {}", changedStatus);
 			throw new BusinessException(INVALID_ORDER_STATUS);
 		}
 
 		OrderStatus currentStatus = OrderStatus.valueOf(orderStatus.name());
 
 		if (isUnchangeableStatus(currentStatus)) {
-			log.warn(currentStatus.getText());
+			log.warn("GET:READ:CAN_NOT_CHANGE_STATUS: CURRENT_STATUS{}", currentStatus.getText());
 			throw new BusinessException(UNCHANGEABLE_ORDER_STATUS);
 		}
 	}
 
 	private void validateDemand(String demand) {
 		if (demand.length() > MAX_DEMAND_LENGTH) {
+			log.warn("POST:WRITE:TOO_LONG_DEMAND:LENGTH {}", demand.length());
 			throw new BusinessException(INVALID_DEMAND_LENGTH);
 		}
 	}
@@ -154,6 +159,8 @@ public class Order extends BaseEntity {
 		}
 
 		if (arrivalTime.isBefore(storeOpenTime) && arrivalTime.isAfter(storeCloseTime)) {
+			log.warn("POST:WRITE:INVALID_ARRIVAL_TIME:STORE_OPEN {}, STORE_CLOSE {}, ARRIVAL_TIME {}", storeOpenTime,
+				storeCloseTime, arrivalTime);
 			throw new BusinessException(INVALID_ARRIVAL_TIME);
 		}
 	}
@@ -165,10 +172,12 @@ public class Order extends BaseEntity {
 	private void validateUpdaterAuthority(Member updater, String originalStatus, String changedStatus) {
 		Pair<String, String> inputSequence = Pair.of(originalStatus, changedStatus);
 
-		if (isMember(updater) && !orderStatusSequenceOfMember.contains(inputSequence)) { //고객인 경우
+		if (isMember(updater) && !orderStatusSequenceOfMember.contains(inputSequence)) {
+			log.warn("PATCH:UPDATE:MEMBER:CANNOT_CHANGE_STATUS:{} -> {}", originalStatus, changedStatus);
 			throw new BusinessException(INVALID_ORDER_STATUS);
 		}
 		if (isStoreOwner(updater) && !OrderStatusSequenceOfStore.contains(inputSequence)) {
+			log.warn("PATCH:UPDATE:STORE:CANNOT_CHANGE_STATUS:{} -> {}", originalStatus, changedStatus);
 			throw new BusinessException(INVALID_ORDER_STATUS);
 		}
 	}

--- a/src/main/java/com/palpal/dealightbe/domain/order/domain/OrderStatus.java
+++ b/src/main/java/com/palpal/dealightbe/domain/order/domain/OrderStatus.java
@@ -1,5 +1,7 @@
 package com.palpal.dealightbe.domain.order.domain;
 
+import java.util.Arrays;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +14,9 @@ public enum OrderStatus {
 	CANCELED("주문 취소");
 
 	private final String text;
+
+	public static boolean isValidStatus(String status) {
+		return Arrays.stream(OrderStatus.values())
+			.anyMatch(orderStatus -> orderStatus.name().equals(status));
+	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/order/presentation/OrderController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/order/presentation/OrderController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,13 +14,15 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.palpal.dealightbe.domain.order.application.OrderService;
 import com.palpal.dealightbe.domain.order.application.dto.request.OrderCreateReq;
+import com.palpal.dealightbe.domain.order.application.dto.request.OrderStatusUpdateReq;
 import com.palpal.dealightbe.domain.order.application.dto.response.OrderRes;
+import com.palpal.dealightbe.domain.order.application.dto.response.OrderStatusUpdateRes;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/orders")
+@RequestMapping("/api/orders")
 public class OrderController {
 
 	private final OrderService orderService;
@@ -41,4 +44,18 @@ public class OrderController {
 		return ResponseEntity.created(uri)
 			.body(orderRes);
 	}
+
+	@PatchMapping("/{orderId}/status/{memberProviderId}")
+	public ResponseEntity<OrderStatusUpdateRes> updateStatus(
+		@Validated @RequestBody OrderStatusUpdateReq orderStatusUpdateReq,
+		@PathVariable Long orderId,
+		@PathVariable Long memberProviderId
+	) {
+
+		OrderStatusUpdateRes orderStatusUpdateRes = orderService.updateStatus(orderId, orderStatusUpdateReq,
+			memberProviderId);
+
+		return ResponseEntity.ok(orderStatusUpdateRes);
+	}
+
 }

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -37,8 +37,13 @@ public enum ErrorCode {
 	NOT_FOUND_ORDER("OR001", "존재하지 않는 주문입니다."),
 	INVALID_ARRIVAL_TIME("OR002", "예상 도착 시간은 업체 마감 시간 이전이어야 합니다."),
 	INVALID_DEMAND_LENGTH("OR003", "요청 사항은 최대 100자까지 입력할 수 있습니다."),
+	INVALID_ORDER_STATUS("OR004", "유효하지 않은 주문 상태입니다."),
+	INVALID_ORDER_STATUS_UPDATER("OR005", "주문을 받은 업체만 주문 상태를 변경할 수 있습니다."),
+	EXCEEDED_ORDER_ITEMS("OR006", "한 번에 5개 종류의 상품까지만 주문할 수 있습니다."),
+	UNCHANGEABLE_ORDER_STATUS("OR007", "주문 완료 또는 주문 취소 상태에서는 상태 변경이 불가능합니다."),
 
 	;
+
 	private final String code;
 	private final String message;
 }

--- a/src/test/java/com/palpal/dealightbe/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/order/application/OrderServiceTest.java
@@ -1,0 +1,347 @@
+package com.palpal.dealightbe.domain.order.application;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalTime;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.palpal.dealightbe.domain.member.domain.Member;
+import com.palpal.dealightbe.domain.member.domain.MemberRepository;
+import com.palpal.dealightbe.domain.order.application.dto.request.OrderStatusUpdateReq;
+import com.palpal.dealightbe.domain.order.application.dto.response.OrderStatusUpdateRes;
+import com.palpal.dealightbe.domain.order.domain.Order;
+import com.palpal.dealightbe.domain.order.domain.OrderRepository;
+import com.palpal.dealightbe.domain.order.domain.OrderStatus;
+import com.palpal.dealightbe.domain.store.domain.DayOff;
+import com.palpal.dealightbe.domain.store.domain.Store;
+import com.palpal.dealightbe.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+class OrderServiceTest {
+
+	@Mock
+	private OrderRepository orderRepository;
+	@Mock
+	private MemberRepository memberRepository;
+
+	@InjectMocks
+	private OrderService orderService;
+
+	public static Member member;
+	public static Member storeOwner;
+	public static Store store;
+	public static Order order;
+
+	public static final long MEMBER_ID = 1234L;
+	public static final long STORE_OWNER_ID = 1235L;
+
+	@BeforeAll
+	static void beforeAll() {
+		member = Member.builder()
+			.providerId(MEMBER_ID)
+			.build();
+
+		storeOwner = Member.builder()
+			.providerId(STORE_OWNER_ID)
+			.build();
+
+		store = Store.builder()
+			.name("GS25")
+			.storeNumber("12341432")
+			.telephone("022341321")
+			.openTime(LocalTime.of(9, 0))
+			.closeTime(LocalTime.of(18, 0))
+			.dayOff(Set.of(DayOff.SAT, DayOff.SUN))
+			.build();
+
+		store.updateMember(storeOwner);
+
+	}
+
+	@Nested
+	@DisplayName("<주문 상태 변경>")
+	class UpdateStatusTest {
+		@Nested
+		@DisplayName("고객")
+		class Member {
+			@Test
+			@DisplayName("'주문 확인' 상태에서 주문을 취소 할 수 있다")
+			void member_statusUpdate_ReceivedToCanceled() {
+				// given
+				order = createOrder();
+
+				when(memberRepository.findMemberByProviderId(MEMBER_ID))
+					.thenReturn(Optional.of(member));
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+
+				OrderStatus changedStatus = OrderStatus.CANCELED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				OrderStatusUpdateRes orderStatusUpdateRes
+					= orderService.updateStatus(0L, orderStatusUpdateReq, MEMBER_ID);
+
+				// then
+				assertThat(orderStatusUpdateRes.status(), is(equalTo(changedStatus.name())));
+				assertThat(order.getOrderStatus(), is(equalTo(changedStatus)));
+			}
+
+			@Test
+			@DisplayName("'주문 접수' 상태 에서 주문을 취소 할 수 있다")
+			void member_statusUpdate_ConfirmedToCanceled() {
+				// given
+				order = createOrder();
+
+				when(memberRepository.findMemberByProviderId(MEMBER_ID))
+					.thenReturn(Optional.of(member));
+
+				when(memberRepository.findMemberByProviderId(STORE_OWNER_ID))
+					.thenReturn(Optional.of(storeOwner));
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+
+				orderService.updateStatus(0L, new OrderStatusUpdateReq("CONFIRMED"), STORE_OWNER_ID);
+
+				OrderStatus changedStatus = OrderStatus.CANCELED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				// then
+				assertThat(order.getOrderStatus(), is(equalTo(OrderStatus.CONFIRMED)));
+
+				OrderStatusUpdateRes orderStatusUpdateRes
+					= orderService.updateStatus(0L, orderStatusUpdateReq, MEMBER_ID);
+
+				assertThat(orderStatusUpdateRes.status(), is(equalTo(changedStatus.name())));
+				assertThat(order.getOrderStatus(), is(equalTo(changedStatus)));
+			}
+
+			@Test
+			@DisplayName("'주문 확인' 상태 에서 '주문 접수'로 상태를 변경할 수 없다")
+			void member_statusUpdateFailed_toConfirmed() {
+				// given
+				order = createOrder();
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+				when(memberRepository.findMemberByProviderId(MEMBER_ID))
+					.thenReturn(Optional.of(member));
+
+				OrderStatus changedStatus = OrderStatus.CONFIRMED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				// then
+				assertThrows(BusinessException.class, () -> {
+					orderService.updateStatus(0L, orderStatusUpdateReq, MEMBER_ID);
+				});
+			}
+
+			@Test
+			@DisplayName("'주문 확인' 상태 에서 '주문 완료'로 상태를 변경할 수 없다")
+			void member_statusUpdateFailed_toCompleted() {
+				// given
+				order = createOrder();
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+				when(memberRepository.findMemberByProviderId(MEMBER_ID))
+					.thenReturn(Optional.of(member));
+
+				OrderStatus changedStatus = OrderStatus.COMPLETED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				// then
+				assertThrows(BusinessException.class, () -> {
+					orderService.updateStatus(0L, orderStatusUpdateReq, MEMBER_ID);
+				});
+			}
+		}
+
+		@Nested
+		@DisplayName("업체")
+		class Store {
+			@Test
+			@DisplayName("'주문 확인'에서 '주문 접수'로 상태를 변경 할 수 있다")
+			void store_statusUpdate_receivedToConfirmed() {
+				// given
+				order = createOrder();
+
+				when(memberRepository.findMemberByProviderId(STORE_OWNER_ID))
+					.thenReturn(Optional.of(storeOwner));
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+
+				OrderStatus changedStatus = OrderStatus.CONFIRMED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				OrderStatusUpdateRes orderStatusUpdateRes
+					= orderService.updateStatus(0L, orderStatusUpdateReq, STORE_OWNER_ID);
+
+				// then
+				assertThat(orderStatusUpdateRes.status(), is(equalTo(changedStatus.name())));
+				assertThat(order.getOrderStatus(), is(equalTo(changedStatus)));
+			}
+
+			@Test
+			@DisplayName("'주문 접수'에서 '주문 완료'로 상태를 변경 할 수 있다")
+			void store_statusUpdate_confirmedToCompleted() {
+				// given
+
+				order = createOrder();
+				when(memberRepository.findMemberByProviderId(STORE_OWNER_ID))
+					.thenReturn(Optional.of(storeOwner));
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+
+				orderService.updateStatus(0L, new OrderStatusUpdateReq("CONFIRMED"), STORE_OWNER_ID);
+
+				OrderStatus changedStatus = OrderStatus.COMPLETED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				// then
+				assertThat(order.getOrderStatus(), is(equalTo(OrderStatus.CONFIRMED)));
+
+				OrderStatusUpdateRes orderStatusUpdateRes
+					= orderService.updateStatus(0L, orderStatusUpdateReq, STORE_OWNER_ID);
+
+				assertThat(orderStatusUpdateRes.status(), is(equalTo(changedStatus.name())));
+				assertThat(order.getOrderStatus(), is(equalTo(changedStatus)));
+			}
+
+			@Test
+			@DisplayName("'주문 확인' 상태에서 주문을 취소할 수 있다")
+			void store_statusUpdate_receivedToCanceled() {
+				// given
+				order = createOrder();
+
+				when(memberRepository.findMemberByProviderId(STORE_OWNER_ID))
+					.thenReturn(Optional.of(storeOwner));
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+
+				OrderStatus changedStatus = OrderStatus.CANCELED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				OrderStatusUpdateRes orderStatusUpdateRes
+					= orderService.updateStatus(0L, orderStatusUpdateReq, STORE_OWNER_ID);
+
+				// then
+				assertThat(orderStatusUpdateRes.status(), is(equalTo(changedStatus.name())));
+				assertThat(order.getOrderStatus(), is(equalTo(changedStatus)));
+			}
+
+			@Test
+			@DisplayName("'주문 접수' 상태에서 주문을 취소할 수 있다")
+			void store_statusUpdate_confirmedToCanceled() {
+				// given
+				order = createOrder();
+
+				when(memberRepository.findMemberByProviderId(STORE_OWNER_ID))
+					.thenReturn(Optional.of(storeOwner));
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+
+				orderService.updateStatus(0L, new OrderStatusUpdateReq("CONFIRMED"), STORE_OWNER_ID);
+
+				OrderStatus changedStatus = OrderStatus.CANCELED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				// then
+				assertThat(order.getOrderStatus(), is(equalTo(OrderStatus.CONFIRMED)));
+
+				OrderStatusUpdateRes orderStatusUpdateRes
+					= orderService.updateStatus(0L, orderStatusUpdateReq, STORE_OWNER_ID);
+
+				assertThat(orderStatusUpdateRes.status(), is(equalTo(changedStatus.name())));
+				assertThat(order.getOrderStatus(), is(equalTo(changedStatus)));
+			}
+
+			@Test
+			@DisplayName("'주문 확인' 상태 에서 주문 접수 없이 바로 '주문 완료'로 상태를 변경할 수 없다")
+			void store_statusUpdateFailed_miss() {
+				// given
+				order = createOrder();
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+				when(memberRepository.findMemberByProviderId(STORE_OWNER_ID))
+					.thenReturn(Optional.of(storeOwner));
+
+				OrderStatus changedStatus = OrderStatus.COMPLETED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				// then
+				assertThrows(BusinessException.class, () -> {
+					orderService.updateStatus(0L, orderStatusUpdateReq, STORE_OWNER_ID);
+				});
+			}
+
+			@Test
+			@DisplayName("'주문 접수' 상태 에서 '주문 확인' 인 이전 상태로 되돌아 갈 수 없다")
+			void store_statusUpdateFailed_undo() {
+				// given
+				order = createOrder();
+
+				when(orderRepository.findById(anyLong()))
+					.thenReturn(Optional.of(order));
+				when(memberRepository.findMemberByProviderId(STORE_OWNER_ID))
+					.thenReturn(Optional.of(storeOwner));
+
+				orderService.updateStatus(0L, new OrderStatusUpdateReq("CONFIRMED"), STORE_OWNER_ID);
+
+				OrderStatus changedStatus = OrderStatus.RECEIVED;
+				OrderStatusUpdateReq orderStatusUpdateReq = new OrderStatusUpdateReq(changedStatus.name());
+
+				// when
+				// then
+
+				assertThat(order.getOrderStatus(), is(equalTo(OrderStatus.CONFIRMED)));
+
+				assertThrows(BusinessException.class, () -> {
+					orderService.updateStatus(0L, orderStatusUpdateReq, STORE_OWNER_ID);
+				});
+			}
+		}
+	}
+
+	private Order createOrder() {
+		return Order.builder()
+			.demand("도착할 때까지 상품 냉장고에 보관 부탁드려요")
+			.arrivalTime(LocalTime.of(12, 30))
+			.store(store)
+			.member(member)
+			.build();
+	}
+
+}

--- a/src/test/java/com/palpal/dealightbe/domain/order/presentation/OrderControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/order/presentation/OrderControllerTest.java
@@ -257,7 +257,7 @@ public class OrderControllerTest {
 						parameterWithName("memberProviderId").description("고객 카카오 토큰")),
 					requestFields(fieldWithPath("status").type(JsonFieldType.STRING)
 						.description("변경 후의 주문 상태(CONFIRMED, COMPLETED, CANCELED)")),
-					responseFields(fieldWithPath("orderId").type(JsonFieldType.NUMBER).description("등록된 주문의 아이디"),
+					responseFields(fieldWithPath("orderId").type(JsonFieldType.NUMBER).description("상태가 변경된 주문의 아이디"),
 						fieldWithPath("status").type(JsonFieldType.STRING).description("변경 완료된 후의 주문 상태"))));
 		}
 


### PR DESCRIPTION
## 💡 관련 이슈

- close: #15

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

주문 상태 사이의 변경을 위한 API 입니다.(주문 확인, 주문 접수, 주문 완료, 주문 취소)

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명

- 주문 상태 종류
  - 주문 확인(RECEIVED)
  - 주문 접수(CONFIRMED)
  - 주문 완료(COMPLETED)
  - 주문 취소(CANCELED)

- 고객
  -  주문 확인/주문 접수 상태에서 주문을 취소할 수 있습니다.
      - RECEIVED -> CANCELED
      - CONFIRMED -> CANCELED
- 업체
  -  주문 접수 상태에서 승인하거나 취소할 수 있습니다.
      - RECEIVED -> CANCELED
      - RECEIVED -> CONFIRMED
  -  주문 승인 상태에서 완료하거나 취소할 수 있습니다.
      - CONFIRMED -> CANCELED
      - CONFIRMED -> COMPLETED

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->

위에 적은 주문 상태 사이의 변경 가능 조건을 Order 클래스 내의 `orderStatusSequenceOfMember`, `orderStatusSequenceOfMember` 라는 이름으로 정의해 두었습니다!