### PR TITLE
고객 프로필 이미지 삭제 API

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -109,3 +109,29 @@ include::{snippets}/member-upload-image-not-found/request-parts.adoc[]
 ==== Response
 
 include::{snippets}/member-upload-image-not-found/http-response.adoc[]
+
+== 멤버 이미지 삭제 성공
+
+=== /api/members/images/{memberId} [DELETE]
+
+==== Request
+
+include::{snippets}/member-delete-image-success/http-request.adoc[]
+include::{snippets}/member-delete-image-success/path-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/member-delete-image-success/http-response.adoc[]
+
+== 멤버 이미지 삭제 실패: 멤버 ID가 존재하지 않는 경우
+
+=== /api/members/images/{memberId} [DELETE]
+
+==== Request
+
+include::{snippets}/member-delete-image-not-found/http-request.adoc[]
+include::{snippets}/member-delete-image-not-found/path-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/member-delete-image-not-found/http-response.adoc[]

--- a/src/main/java/com/palpal/dealightbe/domain/member/application/MemberService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/application/MemberService.java
@@ -101,6 +101,5 @@ public class MemberService {
 
 		imageService.delete(imageUrl);
 		member.updateImage(StoreService.DEFAULT_PATH);
-		memberRepository.save(member);
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/member/application/MemberService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/application/MemberService.java
@@ -1,10 +1,13 @@
 package com.palpal.dealightbe.domain.member.application;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.palpal.dealightbe.domain.address.application.dto.request.AddressReq;
 import com.palpal.dealightbe.domain.address.application.dto.response.AddressRes;
+import com.palpal.dealightbe.domain.auth.application.AuthService;
 import com.palpal.dealightbe.domain.image.ImageService;
 import com.palpal.dealightbe.domain.image.dto.request.ImageUploadReq;
 import com.palpal.dealightbe.domain.image.dto.response.ImageRes;
@@ -13,7 +16,9 @@ import com.palpal.dealightbe.domain.member.application.dto.response.MemberProfil
 import com.palpal.dealightbe.domain.member.application.dto.response.MemberUpdateRes;
 import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.domain.member.domain.MemberRepository;
+import com.palpal.dealightbe.domain.store.application.StoreService;
 import com.palpal.dealightbe.global.error.ErrorCode;
+import com.palpal.dealightbe.global.error.exception.BusinessException;
 import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -78,5 +83,24 @@ public class MemberService {
 		memberRepository.save(member);
 
 		return ImageRes.from(member.getImage());
+	}
+
+	public void deleteMemberImage(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> {
+				log.warn("DELETE:DELETE:NOT_FOUND_MEMBER_BY_ID : {}", memberId);
+				return new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER);
+			});
+
+		String imageUrl = member.getImage();
+
+		if (Objects.equals(imageUrl, AuthService.MEMBER_DEFAULT_IMAGE_PATH)) {
+			log.warn("DELETE:DELETE:DEFAULT_IMAGE_ALREADY_SET : {}", memberId);
+			throw new BusinessException(ErrorCode.DEFAULT_IMAGE_ALREADY_SET);
+		}
+
+		imageService.delete(imageUrl);
+		member.updateImage(StoreService.DEFAULT_PATH);
+		memberRepository.save(member);
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/presentation/MemberController.java
@@ -1,6 +1,7 @@
 package com.palpal.dealightbe.domain.member.presentation;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -59,5 +60,13 @@ public class MemberController {
 		ImageRes imageRes = memberService.updateMemberImage(memberId, imageUploadReq);
 
 		return ResponseEntity.ok(imageRes);
+	}
+
+	@DeleteMapping("/images/{memberId}")
+	public ResponseEntity<Void> deleteMemberImage(@PathVariable Long memberId) {
+		memberService.deleteMemberImage(memberId);
+
+		return ResponseEntity.noContent()
+			.build();
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 
 	//멤버
 	NOT_FOUND_MEMBER("M001", "고객을 찾을 수 없습니다."),
+	DEFAULT_IMAGE_ALREADY_SET("M002", "기본 이미지로 설정된 이미지는 삭제할 수 없습니다."),
 
 	//업체
 	INVALID_BUSINESS_TIME("ST001", "마감 시간은 오픈 시간보다 이전일 수 없습니다"),

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
 
 	//공용
 	INVALID_INPUT_VALUE("C001", "잘못된 값을 입력하셨습니다."),
-	DEFAULT_IMAGE_ALREADY_SET("C002", "기본 이미지로 설정된 이미지는 삭제할 수 없습니다."),
+	UNAUTHORIZED_REQUEST("C002", "해당 요청을 수행할 권한이 없습니다."),
+	DEFAULT_IMAGE_ALREADY_SET("C003", "기본 이미지로 설정된 이미지는 삭제할 수 없습니다."),
 
 	//멤버
 	NOT_FOUND_MEMBER("M001", "고객을 찾을 수 없습니다."),

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -13,10 +13,10 @@ public enum ErrorCode {
 
 	//공용
 	INVALID_INPUT_VALUE("C001", "잘못된 값을 입력하셨습니다."),
+	DEFAULT_IMAGE_ALREADY_SET("C002", "기본 이미지로 설정된 이미지는 삭제할 수 없습니다."),
 
 	//멤버
 	NOT_FOUND_MEMBER("M001", "고객을 찾을 수 없습니다."),
-	DEFAULT_IMAGE_ALREADY_SET("M002", "기본 이미지로 설정된 이미지는 삭제할 수 없습니다."),
 
 	//업체
 	INVALID_BUSINESS_TIME("ST001", "마감 시간은 오픈 시간보다 이전일 수 없습니다"),

--- a/src/test/java/com/palpal/dealightbe/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/member/application/MemberServiceTest.java
@@ -253,7 +253,6 @@ class MemberServiceTest {
 
 		// then
 		verify(imageService).delete(mockImageUrl);
-		verify(memberRepository).save(mockMember);
 		assertEquals(StoreService.DEFAULT_PATH, mockMember.getImage());
 	}
 


### PR DESCRIPTION
## 💡 관련 이슈

- close: https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/issues/21

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

- 고객 프로필 이미지 삭제 API를 추가했습니다.

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명

- 고객 프로필 이미지 삭제 API를 추가하고, 명세를 위한 테스트코드를 추가했습니다.
- 삭제하고자 하는 프로필의 이미지의 Default 이미지 여부를 확인해 에러를 반환합니다. Default 이미지가 아닌경우 기존의 프로필 이미지는 삭제된 후 Default 이미지로 변경됩니다. 
<img width="757" alt="스크린샷 2023-11-05 오전 5 08 10" src="https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/assets/134909318/6d9a3900-b7f9-403d-b212-862cda97967b">
<img width="758" alt="스크린샷 2023-11-05 오전 5 08 18" src="https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/assets/134909318/42d49231-8b31-4b2b-8176-516e9bb3e7f3">


