### PR TITLE
헤더의 Authorization이 null인 경우 로그인 요청, 회원가입시 기본 위치 기본값으로 수정

### DIFF
--- a/src/main/java/com/palpal/dealightbe/domain/address/domain/Address.java
+++ b/src/main/java/com/palpal/dealightbe/domain/address/domain/Address.java
@@ -17,7 +17,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "addresses")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Address extends BaseEntity {
 
 	@Id
@@ -29,6 +28,12 @@ public class Address extends BaseEntity {
 	private double xCoordinate;
 
 	private double yCoordinate;
+
+	public Address() {
+		this("프로그래머스 강남",
+			37.4974495848055,
+			127.028422526103);
+	}
 
 	@Builder
 	public Address(String name, double xCoordinate, double yCoordinate) {

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
@@ -76,9 +76,9 @@ public class AuthService {
 
 	private Member createRequestMember(MemberSignupReq request) {
 		log.info("요청 정보({})로 Member 객체를 만듭니다...", request);
-		Address newAddress = new Address(null, 0, 0);
+		Address defaultAddress = new Address();
 		Member requestMember = MemberSignupReq.toMember(request);
-		requestMember.updateAddress(newAddress);
+		requestMember.updateAddress(defaultAddress);
 		log.info("Member({}) 객체를 만드는데 성공했습니다.", requestMember);
 
 		return requestMember;

--- a/src/main/java/com/palpal/dealightbe/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/filter/JwtAuthenticationFilter.java
@@ -56,7 +56,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			return;
 		}
 
-		// 유효하지 않은 토큰일 경우 예외메시지를 던지는 것이 필요하다.
+		// 유효하지 않은 토큰일 경우(null, 형식이 잘못된 경우) 예외메시지를 던지는 것이 필요하다.
 		log.warn("Jwt({})가 유효하지 않습니다.", jwt);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TOKEN);
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -71,14 +71,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private String parseTokenFromHttpRequest(HttpServletRequest request) {
 		log.info("요청 메시지로부터 Authorization 헤더 값을 가져옵니다...");
 		String jwtWithBearer = request.getHeader(HttpHeaders.AUTHORIZATION);
-		if (validateTokenFromRequest(jwtWithBearer)) {
+		log.info("jwtWithBearer: {}", jwtWithBearer);
+		boolean isValidToken = validateTokenFromRequest(jwtWithBearer);
+		log.info("isValidToken: {}", isValidToken);
+		if (!isValidToken) {
 			log.warn("Authorization에 값이 존재하지 않습니다.");
 
 			return null;
 		}
 
 		log.info("Authorization({}) 값을 가져오는데 성공했습니다.", jwtWithBearer);
-		String jwt = jwtWithBearer.substring(8);
+		String jwt = jwtWithBearer.substring(7);
 		log.info("Jwt({})를 가져오는데 성공했습니다.", jwt);
 
 		return jwt;

--- a/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
@@ -3,6 +3,7 @@ package com.palpal.dealightbe.domain.auth.presentation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.palpal.dealightbe.domain.auth.application.AuthService;
 import com.palpal.dealightbe.domain.auth.application.dto.request.MemberSignupReq;
 import com.palpal.dealightbe.domain.auth.application.dto.response.MemberSignupRes;
+import com.palpal.dealightbe.global.aop.ProviderId;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/palpal/dealightbe/domain/auth/presentation/CustomOAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/presentation/CustomOAuth2AuthenticationSuccessHandler.java
@@ -53,14 +53,18 @@ public class CustomOAuth2AuthenticationSuccessHandler extends SavedRequestAwareA
 		response.setContentType("application/json;charset=UTF-8");
 		response.setContentLength(responseValue.getBytes(StandardCharsets.UTF_8).length);
 		response.getWriter().write(responseValue);
+		response.getWriter().flush();
+		response.getWriter().close();
 	}
 
 	private void writeRequireRoleResponseToHttpMessage(HttpServletResponse response,
 		JoinRequireRes joinRequireResponse) throws IOException {
 		String responseValue = new ObjectMapper().writeValueAsString(joinRequireResponse);
-		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.setContentType("application/json;charset=UTF-8");
 		response.setContentLength(responseValue.getBytes(StandardCharsets.UTF_8).length);
 		response.getWriter().write(responseValue);
+		response.getWriter().flush();
+		response.getWriter().close();
 	}
 }


### PR DESCRIPTION
## 💡 관련 이슈

- close: #96 

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

수행한 작업을 간단히 요약해주세요.

헤더의 Authorization이 null인 경우(+ 잘못된 토큰인 경우) 로그인 요청에 문제를 해결
회원가입시 Address 기본 위치 기본값으로 생성되도록 수정

## 🔎 작업 상세 설명

주요 기능/로직 및 작업 내용에 관해 설명해주세요.

헤더의 Authorization에 따옴표를 붙여야 토큰 검증이 되는 의문의 문제가 발생했는데,
확인해본 결과 정상 토큰인 경우 검증에 실패하고 정상이 아닌 경우 정상으로 처리되는 버그가 있었습니다! 현재 해결된 상태이고 기존에 프로젝트했을 때처럼 따옴표 없이 헤더로 요청을 보내시면 됩니다.

회원가입시 Address 기본 위치 기본 값은 프로그래머스 강남 교육장 위치로 지정되도록 변경했습니다.

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->