### PR TITLE
Notification 도메인 생성

### DIFF
--- a/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
@@ -1,0 +1,71 @@
+package com.palpal.dealightbe.domain.notification.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import com.palpal.dealightbe.domain.member.domain.Member;
+import com.palpal.dealightbe.domain.order.domain.Order;
+import com.palpal.dealightbe.domain.store.domain.Store;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notifications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id")
+	private Order order;
+
+	@Enumerated(EnumType.STRING)
+	private NotificationType type;
+
+	private String message;
+
+	private boolean isRead = false;
+
+	@Builder
+	public Notification(Member member, Store store, Order order, NotificationType type, String message) {
+		this.member = member;
+		this.store = store;
+		this.order = order;
+		this.type = type;
+		this.message = message;
+	}
+
+	public void markAsRead() {
+		this.isRead = true;
+	}
+
+	public enum NotificationType {
+		ORDER_RECEIVED,
+		ORDER_CONFIRMED,
+		ORDER_COMPLETED,
+		ORDER_CANCELED
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
@@ -15,6 +15,7 @@ import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.domain.order.domain.Order;
 import com.palpal.dealightbe.domain.order.domain.OrderStatus;
 import com.palpal.dealightbe.domain.store.domain.Store;
+import com.palpal.dealightbe.global.BaseEntity;
 import com.palpal.dealightbe.global.error.ErrorCode;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 
@@ -27,7 +28,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "notifications")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification {
+public class Notification extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
@@ -66,13 +66,6 @@ public class Notification extends BaseEntity {
 		this.isRead = true;
 	}
 
-	public enum NotificationType {
-		ORDER_RECEIVED,
-		ORDER_CONFIRMED,
-		ORDER_COMPLETED,
-		ORDER_CANCELED
-	}
-
 	public static String createMessage(OrderStatus orderStatus, Order order) {
 		switch (orderStatus) {
 			case RECEIVED:

--- a/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
@@ -13,7 +13,10 @@ import javax.persistence.Table;
 
 import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.domain.order.domain.Order;
+import com.palpal.dealightbe.domain.order.domain.OrderStatus;
 import com.palpal.dealightbe.domain.store.domain.Store;
+import com.palpal.dealightbe.global.error.ErrorCode;
+import com.palpal.dealightbe.global.error.exception.BusinessException;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -67,5 +70,20 @@ public class Notification {
 		ORDER_CONFIRMED,
 		ORDER_COMPLETED,
 		ORDER_CANCELED
+	}
+
+	public static String createMessage(OrderStatus orderStatus, Order order) {
+		switch (orderStatus) {
+			case RECEIVED:
+				return "새 주문이 도착했습니다: " + order.getId();
+			case CONFIRMED:
+				return "주문이 수락되었습니다: " + order.getId();
+			case COMPLETED:
+				return "주문이 완료되었습니다: " + order.getId();
+			case CANCELED:
+				return "주문이 취소되었습니다: " + order.getId();
+			default:
+				throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+		}
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/notification/domain/NotificationType.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/domain/NotificationType.java
@@ -1,0 +1,15 @@
+package com.palpal.dealightbe.domain.notification.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+	ORDER_RECEIVED("주문 확인"),
+	ORDER_CONFIRMED("주문 접수"),
+	ORDER_COMPLETED("주문 완료"),
+	ORDER_CANCELED("주문 취소");
+
+	private final String description;
+}


### PR DESCRIPTION
## 💡 관련 이슈

- close: https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/issues/104
## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

수행한 작업을 간단히 요약해주세요.
- Notification 도메인을 생성하고 해당 엔티티를 작성했습니다.

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명

주요 기능/로직 및 작업 내용에 관해 설명해주세요.
- Notification 엔티티는 주문의 상태 변경을 구독자(구매자 또는 판매자)에게 알릴 때 사용됩니다. 
- 주문 상태에 따라 적절한 메시지를 생성하고, NotificationType을 설정하여 알림을 생성합니다. 
- 사용자가 알림을 확인했는지 여부를 추적하기 위해 isRead 필드를 추가했습니다.

<img width="509" alt="스크린샷 2023-11-13 오후 6 00 12" src="https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/assets/134909318/4e9456e5-fdfb-4f27-be15-8479f6e96c63">

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->