### PR TITLE
업체 정보 추가등록시 Role 변경해서 토큰 재발급

### DIFF
--- a/src/docs/asciidoc/Auth.adoc
+++ b/src/docs/asciidoc/Auth.adoc
@@ -2,7 +2,7 @@ ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
 
-= REST Docs 상품 API
+= REST Docs Auth API
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
@@ -10,89 +10,215 @@ endif::[]
 :toclevels: 2
 :sectlinks:
 
-[[User-API]]
-== AUTH API
+== POST: 회원가입
 
-=== 회원 가입
+=== 성공
 
-==== /api/auth/signup
-
-.Request Success - 회원 가입 요청
+.Request
 include::{snippets}/auth/auth-signup-success/http-request.adoc[]
-
+.Request Fields
 include::{snippets}/auth/auth-signup-success/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-signup-success/request-body.adoc[]
 
-.Response Success - 회원 가입 응답
+.Response
 include::{snippets}/auth/auth-signup-success/http-response.adoc[]
-
+.Response Fields
 include::{snippets}/auth/auth-signup-success/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-signup-success/response-body.adoc[]
+---
 
-.Request Fail - provider 정보가 없는 회원 가입 요청
+=== 실패: Provider 정보가 없는 경우
+
+.Request
 include::{snippets}/auth/auth-signup-fail-no-provider/http-request.adoc[]
-
+.Request Fields
 include::{snippets}/auth/auth-signup-fail-no-provider/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-signup-fail-no-provider/request-body.adoc[]
 
-.Response Fail - provider 정보가 없는 회원 가입 응답
+.Response
 include::{snippets}/auth/auth-signup-fail-no-provider/http-response.adoc[]
-
+.Response Fields
 include::{snippets}/auth/auth-signup-fail-no-provider/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-signup-fail-no-provider/response-body.adoc[]
+---
 
-.Request Fail - providerId 정보가 없는 회원 가입 요청
+=== 실패: Provider Id 정보가 없는 경우
+
+.Request
 include::{snippets}/auth/auth-signup-fail-no-providerId/http-request.adoc[]
-
+.Request Fields
 include::{snippets}/auth/auth-signup-fail-no-providerId/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-signup-fail-no-providerId/request-body.adoc[]
 
-.Response Fail - providerId 정보가 없는 회원 가입 응답
+.Response
 include::{snippets}/auth/auth-signup-fail-no-providerId/http-response.adoc[]
-
+.Response Fields
 include::{snippets}/auth/auth-signup-fail-no-providerId/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-signup-fail-no-providerId/response-body.adoc[]
+---
 
+=== 실패: 이미 가입이 된 경우
 
-.Request Fail - 중복 회원 가입 요청
+.Request
 include::{snippets}/auth/auth-signup-fail-already-exist/http-request.adoc[]
-
+.Request Fields
 include::{snippets}/auth/auth-signup-fail-already-exist/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-signup-fail-already-exist/request-body.adoc[]
 
-.Response Fail - 중복 회원 가입 응답
+.Response
 include::{snippets}/auth/auth-signup-fail-already-exist/http-response.adoc[]
-
+.Response Fields
 include::{snippets}/auth/auth-signup-fail-already-exist/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-signup-fail-already-exist/response-body.adoc[]
 
-.Request Fail - 잘못된 역할로 회원 가입 요청
-include::{snippets}/auth/auth-signup-fail-invalid-role-request/http-request.adoc[]
+== GET: 로그인
 
-include::{snippets}/auth/auth-signup-fail-invalid-role-request/request-fields.adoc[]
+=== 성공: 이미 회원인 경우
 
-.Response Fail - 잘못된 역할로 회원 가입 응답
-include::{snippets}/auth/auth-signup-fail-invalid-role-request/http-response.adoc[]
+.Request
+include::{snippets}/auth/auth-login-success/http-request.adoc[]
+.Request Parameters
+include::{snippets}/auth/auth-login-success/request-parameters.adoc[]
 
-include::{snippets}/auth/auth-signup-fail-invalid-role-request/response-fields.adoc[]
+.Response
+include::{snippets}/auth/auth-login-success/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-login-success/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-login-success/response-body.adoc[]
 
-.Request Success - 회원 가입 요청
-include::{snippets}/auth/auth-signup-success/http-request.adoc[]
+=== 성공: 가입이 필요한 경우
 
-include::{snippets}/auth/auth-signup-success/request-fields.adoc[]
+.Request
+include::{snippets}/auth/auth-require-signup/http-request.adoc[]
+.Request Parameters
+include::{snippets}/auth/auth-require-signup/request-parameters.adoc[]
 
-.Request Success - 회원 탈퇴 요청
+.Response
+include::{snippets}/auth/auth-require-signup/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-require-signup/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-require-signup/response-body.adoc[]
+
+=== 실패: Authorization Code가 없는 경우
+
+.Request
+include::{snippets}/auth/auth-null-authorization-code-fail/http-request.adoc[]
+.Request Parameters
+include::{snippets}/auth/auth-null-authorization-code-fail//request-parameters.adoc[]
+
+.Response
+include::{snippets}/auth/auth-null-authorization-code-fail//http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-null-authorization-code-fail//response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-null-authorization-code-fail//response-body.adoc[]
+
+=== 실패: Authorization Code가 잘못된 경우
+
+.Request
+include::{snippets}/auth/auth-invalid-authorization-code/http-request.adoc[]
+.Request Parameters
+include::{snippets}/auth/auth-invalid-authorization-code/request-parameters.adoc[]
+
+.Response
+include::{snippets}/auth/auth-invalid-authorization-code/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-invalid-authorization-code/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-invalid-authorization-code/response-body.adoc[]
+
+== DELETE: 회원탈퇴
+
+=== 성공
+
+.Request
 include::{snippets}/auth/auth-unregister-success-request/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-unregister-success-request/request-headers.adoc[]
 
-.Response Success - 회원 탈퇴 응답
+.Response
 include::{snippets}/auth/auth-unregister-success-request/http-response.adoc[]
 
-.Request Fail - 토큰(인증정보)이 올바르지 않은 경우 회원 탈퇴 요청
+=== 실패: 인증이 유효하지 않음
+
+.Request
 include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/request-headers.adoc[]
 
-.Response Fail - 토큰(인증정보)이 올바르지 않은 경우 회원 탈퇴 응답
+.Response
 include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/response-body.adoc[]
 
-.Request Fail - 회원조회가 안되는 경우 회원 탈퇴 요청
+=== 실패: 회원 조회에 실패
+
+.Request
 include::{snippets}/auth/auth-unregister-fail-if-member-not-found/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-unregister-fail-if-member-not-found/request-headers.adoc[]
 
-.Response Fail - 회원조회가 안되는 경우 회원 탈퇴 응답
+.Response
 include::{snippets}/auth/auth-unregister-fail-if-member-not-found/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-unregister-fail-if-member-not-found/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-unregister-fail-if-member-not-found/response-body.adoc[]
 
-.Request Success - Access Token 재발급 요청
+== GET: 토큰 재발급
+
+=== 성공
+
+.Request
 include::{snippets}/auth/auth-reissue-token-success-request/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-reissue-token-success-request/request-headers.adoc[]
 
-.Response Success - Access Token 재발급 응답
+.Response
 include::{snippets}/auth/auth-reissue-token-success-request/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-reissue-token-success-request/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-reissue-token-success-request/response-body.adoc[]
+
+=== 실패: 회원 조회에 실패
+
+.Request
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/request-headers.adoc[]
+
+.Response
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/response-body.adoc[]
+
+== PATCH: ROLE을 store로 변경
+
+=== 성공
+
+.Request
+include::{snippets}/auth/auth-change-role-success/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-change-role-success/request-headers.adoc[]
+
+.Response
+include::{snippets}/auth/auth-change-role-success/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-change-role-success/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-change-role-success/response-body.adoc[]

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
@@ -141,11 +141,7 @@ public class AuthService {
 	}
 
 	public MemberAuthRes updateMemberRoleToStore(Long providerId) {
-		Member member = memberRepository.findMemberByProviderId(providerId)
-			.orElseThrow(() -> {
-				log.warn("READ:NOT_FOUND_MEMBER_BY_PROVIDER_ID : {}", providerId);
-				return new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER);
-			});
+		Member member = findMemberByProviderId(providerId);
 
 		List<MemberRole> assignableMemberRoles = createMemberRoles(RoleType.ROLE_STORE, member);
 		List<MemberRole> savedMemberRoles = memberRoleRepository.saveAll(assignableMemberRoles);

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
@@ -98,20 +98,16 @@ public class AuthService {
 		log.info("사용자(ProviderId:{})의 회원탈퇴를 진행합니다...", providerId);
 
 		Member member = findMemberByProviderId(providerId);
-
 		log.info("사용자({})를 조회하는데 성공했습니다.", member);
 
 		if (!member.hasSameImage(MEMBER_DEFAULT_IMAGE_PATH)) {
 			String memberImage = member.getImage();
 			log.info("사용자(ProviderId:{})의 이미지({})를 삭제합니다...", providerId, memberImage);
-
 			imageService.delete(memberImage);
-
 			log.info("이미지 삭제에 성공했습니다.");
 		}
 
 		log.info("사용자(ProviderId:{})의 정보를 삭제합니다...", providerId);
-
 		memberRepository.delete(member);
 
 		log.info("회원탈퇴에 성공했습니다.");

--- a/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
@@ -72,7 +72,7 @@ public class AuthController {
 	}
 
 	@ProviderId
-	@PatchMapping("/role/store")
+	@PatchMapping("/role")
 	public ResponseEntity<MemberAuthRes> updateMemberRoleToStore(Long providerId) {
 		MemberAuthRes memberAuthRes = authService.updateMemberRoleToStore(providerId);
 

--- a/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,7 +54,7 @@ public class AuthController {
 	@ProviderId
 	@GetMapping("/reissue")
 	public ResponseEntity<MemberAuthRes> reissueToken(Long providerId, String refreshToken) {
-		MemberAuthRes response = authService.reIssueToken(providerId, refreshToken);
+		MemberAuthRes response = authService.reissueToken(providerId, refreshToken);
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
@@ -68,5 +69,13 @@ public class AuthController {
 		return ResponseEntity
 			.noContent()
 			.build();
+	}
+
+	@ProviderId
+	@PatchMapping("/role/store")
+	public ResponseEntity<MemberAuthRes> updateMemberRoleToStore(Long providerId) {
+		MemberAuthRes memberAuthRes = authService.updateMemberRoleToStore(providerId);
+
+		return ResponseEntity.ok(memberAuthRes);
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
@@ -55,7 +55,7 @@ public class Member extends BaseEntity {
 
 	private String image;
 
-	@OneToMany(fetch = FetchType.LAZY, mappedBy = "member", cascade = CascadeType.ALL)
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<MemberRole> memberRoles = new ArrayList<>();
 
 	@Builder

--- a/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
@@ -108,7 +108,7 @@ public class Member extends BaseEntity {
 	}
 
 	public boolean hasSameImage(String imageUrl) {
-		return this.image.equals(imageUrl);
+		return this.image != null && this.image.equals(imageUrl);
 	}
 
 	@Override

--- a/src/main/java/com/palpal/dealightbe/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/GlobalExceptionHandler.java
@@ -36,13 +36,6 @@ public class GlobalExceptionHandler {
 		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
 	}
 
-	@ExceptionHandler(IllegalArgumentException.class)
-	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.UNABLE_TO_HANDLE_ERROR);
-
-		return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
-	}
-
 	@ExceptionHandler(RequiredAuthenticationException.class)
 	public ResponseEntity<ErrorResponse> handleRequiredAuthenticationException(RequiredAuthenticationException e) {
 		// 인증을 필요로하지만 토큰이 헤더에 들어있지 않은 경우(토큰이 null인 경우)

--- a/src/test/java/com/palpal/dealightbe/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/application/AuthServiceTest.java
@@ -3,9 +3,13 @@ package com.palpal.dealightbe.domain.auth.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +19,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -29,6 +35,7 @@ import com.palpal.dealightbe.domain.auth.application.dto.response.MemberAuthRes;
 import com.palpal.dealightbe.domain.auth.application.dto.response.OAuthLoginRes;
 import com.palpal.dealightbe.domain.auth.application.dto.response.OAuthUserInfoRes;
 import com.palpal.dealightbe.domain.auth.domain.Jwt;
+import com.palpal.dealightbe.domain.image.ImageService;
 import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.domain.member.domain.MemberRepository;
 import com.palpal.dealightbe.domain.member.domain.MemberRole;
@@ -37,10 +44,13 @@ import com.palpal.dealightbe.domain.member.domain.Role;
 import com.palpal.dealightbe.domain.member.domain.RoleRepository;
 import com.palpal.dealightbe.domain.member.domain.RoleType;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
+import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
+	@Mock
+	private ImageService imageService;
 	@Mock
 	private MemberRepository memberRepository;
 	@Mock
@@ -64,6 +74,7 @@ class AuthServiceTest {
 			.build();
 		MemberRole memberRole = new MemberRole(member, role);
 		member.updateMemberRoles(Collections.singletonList(memberRole));
+		member.updateImage("MOCK_IMAGE_URL");
 	}
 
 	@DisplayName("Dealight에 등록된 사용자일 경우 MemberAuthRes 반환")
@@ -96,9 +107,9 @@ class AuthServiceTest {
 			.isNotEmpty();
 	}
 
-	@DisplayName("Dealight에 등록된 사용자가 아닐 경우 JoinRequireRes를 반환")
+	@DisplayName("Dealight에 등록된 사용자가 아닐 경우 OAuthUserInfoRes를 반환")
 	@Test
-	void loginFailIfNotRegisteredMemberReturnJoinRequireRes() {
+	void loginFailIfNotRegisteredMemberReturnOAuthUserInfoRes() {
 		// given
 		Long mockProviderId = 12345L;
 		OAuthUserInfoRes oAuthUserInfoRes
@@ -199,8 +210,10 @@ class AuthServiceTest {
 		MemberAuthRes response = authService.signup(memberSignupReq);
 
 		// then
-		assertThat(response.accessToken()).isEqualTo("MOCK_ACCESS_TOKEN");
-		assertThat(response.refreshToken()).isEqualTo("MOCK_REFRESH_TOKEN");
+		assertThat(response.accessToken())
+			.isEqualTo("MOCK_ACCESS_TOKEN");
+		assertThat(response.refreshToken())
+			.isEqualTo("MOCK_REFRESH_TOKEN");
 	}
 
 	@DisplayName("이미 존재하는 회원인 경우 회원가입 실패")
@@ -220,5 +233,146 @@ class AuthServiceTest {
 		// when -> then
 		assertThatThrownBy(() -> authService.signup(request))
 			.isInstanceOf(BusinessException.class);
+	}
+
+	@DisplayName("회원탈퇴 성공")
+	@Test
+	void unregisterSuccess() {
+		// given
+		Long providerId = member.getProviderId();
+		when(memberRepository.findMemberByProviderId(providerId))
+			.thenReturn(Optional.of(member));
+		doNothing().when(imageService)
+			.delete(any());
+
+		// when
+		authService.unregister(providerId);
+
+		// then
+		verify(memberRepository, times(1))
+			.delete(member);
+	}
+
+	@DisplayName("기본 이미지라면 삭제하지 않고, 회원탈퇴 성공")
+	@Test
+	void unregisterSuccessIfMemberHaveDefaultImage() {
+		// given
+		Long providerId = member.getProviderId();
+		String memberImage = member.getImage();
+		member.updateImage("https://team-08-bucket.s3.ap-northeast-2.amazonaws.com/image/member-default-image.png");
+		when(memberRepository.findMemberByProviderId(providerId))
+			.thenReturn(Optional.of(member));
+
+		// when
+		authService.unregister(providerId);
+
+		// then
+		verify(imageService, times(0))
+			.delete(memberImage);
+		verify(memberRepository, times(1))
+			.delete(member);
+	}
+
+	@DisplayName("회원정보 조회에 실패할 경우, 회원탈퇴 실패")
+	@Test
+	void unregisterFailIfNotFoundMember() {
+		// given
+		Long providerId = member.getProviderId();
+		when(memberRepository.findMemberByProviderId(providerId))
+			.thenReturn(Optional.empty());
+
+		// when ->then
+		assertThatThrownBy(() -> authService.unregister(providerId))
+			.isInstanceOf(EntityNotFoundException.class);
+		verify(memberRepository, times(0))
+			.delete(member);
+	}
+
+	@DisplayName("Token 재발급 성공: Access Token만 재발급")
+	@ValueSource(longs = {11, 12, 13, 14, 15, 16, 17, 18, 19, 20})
+	@ParameterizedTest
+	void reissueOnlyAccessTokenSuccess(long days) {
+		// given
+		Long providerId = member.getProviderId();
+		String mockRefreshToken = "MOCK_REFRESH_TOKEN";
+		LocalDateTime expiryDateAfter20DaysFromCurrentTime
+			= LocalDateTime.now().plusDays(days);
+		Instant instant = expiryDateAfter20DaysFromCurrentTime
+			.atZone(ZoneId.systemDefault()).toInstant();
+		Date date = Date.from(instant);
+
+		given(memberRepository.findMemberByProviderId(providerId))
+			.willReturn(Optional.of(member));
+		given(jwt.getExpiryDate(mockRefreshToken))
+			.willReturn(date);
+
+		// when
+		authService.reissueToken(providerId, mockRefreshToken);
+
+		// then
+		verify(jwt, times(1))
+			.createAccessToken(member);
+	}
+
+	@DisplayName("Access Token, Refresh Token 모두 재발급 성공")
+	@ValueSource(longs = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	@ParameterizedTest
+	void reissueAllTokenSuccess(long days) {
+		// given
+		Long providerId = member.getProviderId();
+		String mockRefreshToken = "MOCK_REFRESH_TOKEN";
+		LocalDateTime expiryDateAfter20DaysFromCurrentTime
+			= LocalDateTime.now().plusDays(days);
+		Instant instant = expiryDateAfter20DaysFromCurrentTime
+			.atZone(ZoneId.systemDefault()).toInstant();
+		Date date = Date.from(instant);
+
+		given(memberRepository.findMemberByProviderId(providerId))
+			.willReturn(Optional.of(member));
+		given(jwt.getExpiryDate(mockRefreshToken))
+			.willReturn(date);
+
+		// when
+		authService.reissueToken(providerId, mockRefreshToken);
+
+		// then
+		verify(jwt, times(1))
+			.createAccessToken(member);
+		verify(jwt, times(1))
+			.createRefreshToken(member);
+	}
+
+	@DisplayName("Member를 찾지 못하면 토큰 발급 실패")
+	@Test
+	void reissueFailIfMemberNotFound() {
+		// given
+		Long providerId = member.getProviderId();
+		String mockRefreshToken = "MOCK_REFRESH_TOKEN";
+
+		given(memberRepository.findMemberByProviderId(providerId))
+			.willReturn(Optional.empty());
+
+		// when -> then
+		assertThatThrownBy(() -> authService.reissueToken(providerId, mockRefreshToken))
+			.isInstanceOf(EntityNotFoundException.class);
+	}
+
+	@DisplayName("Jwt 객체에 문제가 발생하면 Access Token 발급에 실패")
+	@Test
+	void reissueFailIfJwtIsNotWorking() {
+		// given
+		Long providerId = member.getProviderId();
+		String mockRefreshToken = "MOCK_REFRESH_TOKEN";
+
+		given(memberRepository.findMemberByProviderId(providerId))
+			.willReturn(Optional.of(member));
+		doThrow(RuntimeException.class).when(jwt)
+			.createAccessToken(member);
+
+		// when -> then
+		assertThatThrownBy(() -> authService.reissueToken(providerId, mockRefreshToken))
+			.isInstanceOf(RuntimeException.class);
+		verify(memberRepository, times(1))
+			.findMemberByProviderId(providerId);
 	}
 }

--- a/src/test/java/com/palpal/dealightbe/domain/auth/application/OAuth2AuthorizationServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/application/OAuth2AuthorizationServiceTest.java
@@ -1,9 +1,0 @@
-package com.palpal.dealightbe.domain.auth.application;
-
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-@ExtendWith(MockitoExtension.class)
-class OAuth2AuthorizationServiceTest {
-
-}

--- a/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
@@ -556,7 +556,7 @@ class AuthControllerTest {
 				"REFRESH_TOKEN"
 			);
 
-			given(authService.reIssueToken(any(), any()))
+			given(authService.reissueToken(any(), any()))
 				.willReturn(memberAuthRes);
 
 			// when -> then
@@ -597,7 +597,7 @@ class AuthControllerTest {
 			EntityNotFoundException entityNotFoundException = new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER);
 			doThrow(entityNotFoundException)
 				.when(authService)
-				.reIssueToken(any(), any());
+				.reissueToken(any(), any());
 
 			// when -> then
 			mockMvc.perform(get(reissueTokenApiPath)

--- a/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
@@ -635,7 +635,7 @@ class AuthControllerTest {
 	@DisplayName("<권한변경>")
 	class changeRoleMemberToStore {
 
-		String changeRoleApiPath = "/api/auth/role/store";
+		String changeRoleApiPath = "/api/auth/role";
 
 		@DisplayName("ROLE_MEMBER를 ROLE_STORE로 변경")
 		@Test

--- a/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
@@ -170,7 +170,7 @@ class AuthControllerTest {
 					.isInstanceOf(MissingServletRequestParameterException.class))
 				.andDo(print())
 				.andDo(document(
-					"auth/auth/auth-null-authorization-code-fail",
+					"auth/auth-null-authorization-code-fail",
 					preprocessRequest(prettyPrint()),
 					preprocessResponse(prettyPrint()),
 					requestParameters(

--- a/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
@@ -630,4 +630,55 @@ class AuthControllerTest {
 				));
 		}
 	}
+
+	@Nested
+	@DisplayName("<권한변경>")
+	class changeRoleMemberToStore {
+
+		String changeRoleApiPath = "/api/auth/role/store";
+
+		@DisplayName("ROLE_MEMBER를 ROLE_STORE로 변경")
+		@Test
+		void changeRoleSuccess() throws Exception {
+			// given
+			Long providerId = 12345L;
+			String accessToken = "ACCESS_TOKEN";
+			String refreshToken = "REFRESH_TOKEN";
+			MemberAuthRes memberAuthRes = new MemberAuthRes(providerId, "store", accessToken, refreshToken);
+
+			given(authService.updateMemberRoleToStore(any()))
+				.willReturn(memberAuthRes);
+
+			// when -> then
+			mockMvc.perform(patch(changeRoleApiPath)
+					.header("Authorization", "Bearer {ACCESS_TOKEN}")
+					.with(csrf())
+					.with(user("user").roles("MEMBER"))
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.userId").value(providerId))
+				.andExpect(jsonPath("$.role").value("store"))
+				.andExpect(jsonPath("$.accessToken").value(accessToken))
+				.andExpect(jsonPath("$.refreshToken").value(refreshToken))
+				.andDo(document(
+					"auth/auth-change-role-success",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestHeaders(
+						headerWithName("Authorization").description("Access Token")
+					),
+					responseFields(
+						fieldWithPath("userId").type(JsonFieldType.NUMBER)
+							.description("회원의 ID"),
+						fieldWithPath("role").type(JsonFieldType.STRING)
+							.description("변경된 회원의 Role"),
+						fieldWithPath("accessToken").type(JsonFieldType.STRING)
+							.description("Access Token"),
+						fieldWithPath("refreshToken").type(JsonFieldType.STRING)
+							.description("Refresh Token")
+					)
+				));
+		}
+	}
 }

--- a/src/test/java/com/palpal/dealightbe/domain/store/domain/StoreRepositoryTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/domain/StoreRepositoryTest.java
@@ -223,7 +223,7 @@ public class StoreRepositoryTest {
 		//then
 		assertThat(stores).isNotNull();
 		assertThat(stores).hasSize(2);
-		assertThat(stores.getContent().get(0).getName()).isEqualTo(store.getName());
+		assertThat(stores.getContent().get(0).getName()).isEqualTo(store2.getName());
 	}
 
 	@Test

--- a/src/test/java/com/palpal/dealightbe/domain/store/domain/StoreRepositoryTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/domain/StoreRepositoryTest.java
@@ -223,7 +223,7 @@ public class StoreRepositoryTest {
 		//then
 		assertThat(stores).isNotNull();
 		assertThat(stores).hasSize(2);
-		assertThat(stores.getContent().get(0).getName()).isEqualTo(store2.getName());
+		assertThat(stores.getContent().get(0).getName()).isEqualTo(store.getName());
 	}
 
 	@Test


### PR DESCRIPTION
## 💡 관련 이슈

- close: #182

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

수행한 작업을 간단히 요약해주세요.

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

업체 정보 추가 등록시 Role을 member에서 store로 변경하고
Access Token과 Refresh Token을 재발급합니다.
새로 생긴 엔드 포인트에 관한 테스트 코드를 작성했습니다.
이전에 작성하지 못한 테스트 코드를 추가로 작성했습니다.
전체적으로 Rest Docs 명세를 수정했습니다.

## 🔎 작업 상세 설명

주요 기능/로직 및 작업 내용에 관해 설명해주세요.
- 업체정보 추가등록 후 /api/auth/role에 Access Token을 가지고 요청을 하면 Role을 member에서 store로 변경합니다.
- 변경된 Role에 따라 Access Token과 Refresh Token을 새로 발급합니다.
- 업체 정보 추가 등록 후 Role 변경에 관한 테스트 코드를 작성했습니다.
- AuthController, AuthService에 관한 실패 테스트 코드를 추가로 작성했습니다.
- Auth 관련 Rest Docs에서 빠뜨린 부분을 추가하고 가독성을 향상 시켰습니다.

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->