### PR TITLE
추가 요구사항: 닉네임 중복확인 API 구현

### DIFF
--- a/src/docs/asciidoc/Auth.adoc
+++ b/src/docs/asciidoc/Auth.adoc
@@ -2,7 +2,7 @@ ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
 
-= REST Docs 상품 API
+= REST Docs Auth API
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
@@ -10,89 +10,259 @@ endif::[]
 :toclevels: 2
 :sectlinks:
 
-[[User-API]]
-== AUTH API
+== POST: 닉네임 중복 검사
 
-=== 회원 가입
+=== 성공
 
-==== /api/auth/signup
+.Request
+include::{snippets}/auth/auth-duplicate-nickName-check-success/http-request.adoc[]
+.Request Fields
+include::{snippets}/auth/auth-duplicate-nickName-check-success/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-duplicate-nickName-check-success/request-body.adoc[]
 
-.Request Success - 회원 가입 요청
+.Response
+include::{snippets}/auth/auth-duplicate-nickName-check-success/http-response.adoc[]
+---
+
+=== 실패: 이미 존재하는 닉네임
+
+.Request
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-already-exist/http-request.adoc[]
+.Request Body
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-already-exist/request-body.adoc[]
+
+.Response
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-already-exist/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-already-exist/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-already-exist/response-body.adoc[]
+---
+
+=== 실패: 조건에 맞지 않는 닉네임
+
+.Request
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-not-valid-form/http-request.adoc[]
+.Request Body
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-not-valid-form/request-body.adoc[]
+
+.Response
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-not-valid-form/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-not-valid-form/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-duplicate-nickName-check-fail-not-valid-form/response-body.adoc[]
+
+== POST: 회원가입
+
+=== 성공
+
+.Request
 include::{snippets}/auth/auth-signup-success/http-request.adoc[]
-
+.Request Fields
 include::{snippets}/auth/auth-signup-success/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-signup-success/request-body.adoc[]
 
-.Response Success - 회원 가입 응답
+.Response
 include::{snippets}/auth/auth-signup-success/http-response.adoc[]
-
+.Response Fields
 include::{snippets}/auth/auth-signup-success/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-signup-success/response-body.adoc[]
+---
 
-.Request Fail - provider 정보가 없는 회원 가입 요청
+=== 실패: Provider 정보가 없는 경우
+
+.Request
 include::{snippets}/auth/auth-signup-fail-no-provider/http-request.adoc[]
-
+.Request Fields
 include::{snippets}/auth/auth-signup-fail-no-provider/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-signup-fail-no-provider/request-body.adoc[]
 
-.Response Fail - provider 정보가 없는 회원 가입 응답
+.Response
 include::{snippets}/auth/auth-signup-fail-no-provider/http-response.adoc[]
-
+.Response Fields
 include::{snippets}/auth/auth-signup-fail-no-provider/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-signup-fail-no-provider/response-body.adoc[]
+---
 
-.Request Fail - providerId 정보가 없는 회원 가입 요청
+=== 실패: Provider Id 정보가 없는 경우
+
+.Request
 include::{snippets}/auth/auth-signup-fail-no-providerId/http-request.adoc[]
-
+.Request Fields
 include::{snippets}/auth/auth-signup-fail-no-providerId/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-signup-fail-no-providerId/request-body.adoc[]
 
-.Response Fail - providerId 정보가 없는 회원 가입 응답
+.Response
 include::{snippets}/auth/auth-signup-fail-no-providerId/http-response.adoc[]
-
+.Response Fields
 include::{snippets}/auth/auth-signup-fail-no-providerId/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-signup-fail-no-providerId/response-body.adoc[]
+---
 
+=== 실패: 이미 가입이 된 경우
 
-.Request Fail - 중복 회원 가입 요청
+.Request
 include::{snippets}/auth/auth-signup-fail-already-exist/http-request.adoc[]
-
+.Request Fields
 include::{snippets}/auth/auth-signup-fail-already-exist/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-signup-fail-already-exist/request-body.adoc[]
 
-.Response Fail - 중복 회원 가입 응답
+.Response
 include::{snippets}/auth/auth-signup-fail-already-exist/http-response.adoc[]
-
+.Response Fields
 include::{snippets}/auth/auth-signup-fail-already-exist/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-signup-fail-already-exist/response-body.adoc[]
 
-.Request Fail - 잘못된 역할로 회원 가입 요청
-include::{snippets}/auth/auth-signup-fail-invalid-role-request/http-request.adoc[]
+== GET: 로그인
 
-include::{snippets}/auth/auth-signup-fail-invalid-role-request/request-fields.adoc[]
+=== 성공: 이미 회원인 경우
 
-.Response Fail - 잘못된 역할로 회원 가입 응답
-include::{snippets}/auth/auth-signup-fail-invalid-role-request/http-response.adoc[]
+.Request
+include::{snippets}/auth/auth-login-success/http-request.adoc[]
+.Request Parameters
+include::{snippets}/auth/auth-login-success/request-parameters.adoc[]
 
-include::{snippets}/auth/auth-signup-fail-invalid-role-request/response-fields.adoc[]
+.Response
+include::{snippets}/auth/auth-login-success/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-login-success/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-login-success/response-body.adoc[]
 
-.Request Success - 회원 가입 요청
-include::{snippets}/auth/auth-signup-success/http-request.adoc[]
+=== 성공: 가입이 필요한 경우
 
-include::{snippets}/auth/auth-signup-success/request-fields.adoc[]
+.Request
+include::{snippets}/auth/auth-require-signup/http-request.adoc[]
+.Request Parameters
+include::{snippets}/auth/auth-require-signup/request-parameters.adoc[]
 
-.Request Success - 회원 탈퇴 요청
+.Response
+include::{snippets}/auth/auth-require-signup/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-require-signup/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-require-signup/response-body.adoc[]
+
+=== 실패: Authorization Code가 없는 경우
+
+.Request
+include::{snippets}/auth/auth-null-authorization-code-fail/http-request.adoc[]
+.Request Parameters
+include::{snippets}/auth/auth-null-authorization-code-fail//request-parameters.adoc[]
+
+.Response
+include::{snippets}/auth/auth-null-authorization-code-fail//http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-null-authorization-code-fail//response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-null-authorization-code-fail//response-body.adoc[]
+
+=== 실패: Authorization Code가 잘못된 경우
+
+.Request
+include::{snippets}/auth/auth-invalid-authorization-code/http-request.adoc[]
+.Request Parameters
+include::{snippets}/auth/auth-invalid-authorization-code/request-parameters.adoc[]
+
+.Response
+include::{snippets}/auth/auth-invalid-authorization-code/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-invalid-authorization-code/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-invalid-authorization-code/response-body.adoc[]
+
+== DELETE: 회원탈퇴
+
+=== 성공
+
+.Request
 include::{snippets}/auth/auth-unregister-success-request/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-unregister-success-request/request-headers.adoc[]
 
-.Response Success - 회원 탈퇴 응답
+.Response
 include::{snippets}/auth/auth-unregister-success-request/http-response.adoc[]
 
-.Request Fail - 토큰(인증정보)이 올바르지 않은 경우 회원 탈퇴 요청
+=== 실패: 인증이 유효하지 않음
+
+.Request
 include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/request-headers.adoc[]
 
-.Response Fail - 토큰(인증정보)이 올바르지 않은 경우 회원 탈퇴 응답
+.Response
 include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-unregister-fail-if-authentication-not-valid/response-body.adoc[]
 
-.Request Fail - 회원조회가 안되는 경우 회원 탈퇴 요청
+=== 실패: 회원 조회에 실패
+
+.Request
 include::{snippets}/auth/auth-unregister-fail-if-member-not-found/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-unregister-fail-if-member-not-found/request-headers.adoc[]
 
-.Response Fail - 회원조회가 안되는 경우 회원 탈퇴 응답
+.Response
 include::{snippets}/auth/auth-unregister-fail-if-member-not-found/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-unregister-fail-if-member-not-found/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-unregister-fail-if-member-not-found/response-body.adoc[]
 
-.Request Success - Access Token 재발급 요청
+== GET: 토큰 재발급
+
+=== 성공
+
+.Request
 include::{snippets}/auth/auth-reissue-token-success-request/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-reissue-token-success-request/request-headers.adoc[]
 
-.Response Success - Access Token 재발급 응답
+.Response
 include::{snippets}/auth/auth-reissue-token-success-request/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-reissue-token-success-request/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-reissue-token-success-request/response-body.adoc[]
+
+=== 실패: 회원 조회에 실패
+
+.Request
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/request-headers.adoc[]
+
+.Response
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-reissue-token-fail-if-not-found-member/response-body.adoc[]
+
+== PATCH: ROLE을 store로 변경
+
+=== 성공
+
+.Request
+include::{snippets}/auth/auth-change-role-success/http-request.adoc[]
+.Request Headers
+include::{snippets}/auth/auth-change-role-success/request-headers.adoc[]
+
+.Response
+include::{snippets}/auth/auth-change-role-success/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-change-role-success/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-change-role-success/response-body.adoc[]

--- a/src/main/java/com/palpal/dealightbe/config/SecurityConfig.java
+++ b/src/main/java/com/palpal/dealightbe/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
 			).permitAll()
 			// 서비스 URL
 			.antMatchers(HttpMethod.OPTIONS,
-				"/api/auth/signup"
+				"/api/auth/signup", "/api/auth/duplicate"
 			).permitAll()
 			.antMatchers(HttpMethod.OPTIONS,
 				"/api/**"

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/AuthService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.palpal.dealightbe.domain.address.domain.Address;
+import com.palpal.dealightbe.domain.auth.application.dto.request.MemberNickNameCheckReq;
 import com.palpal.dealightbe.domain.auth.application.dto.request.MemberSignupAuthReq;
 import com.palpal.dealightbe.domain.auth.application.dto.response.MemberAuthRes;
 import com.palpal.dealightbe.domain.auth.application.dto.response.OAuthLoginRes;
@@ -142,6 +143,15 @@ public class AuthService {
 		}
 
 		return createMemberAuthRes(member, newAccessToken, refreshToken);
+	}
+
+	@Transactional(readOnly = true)
+	public void checkDuplicateNickName(MemberNickNameCheckReq request) {
+		String nickName = request.nickName();
+		boolean isDuplicate = memberRepository.existsByNickName(nickName);
+		if (isDuplicate) {
+			throw new BusinessException(ErrorCode.DUPLICATED_NICK_NAME);
+		}
 	}
 
 	private boolean checkRefreshTokenAroundExpiryDate(String refreshToken) {

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/dto/request/MemberNickNameCheckReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/dto/request/MemberNickNameCheckReq.java
@@ -5,7 +5,7 @@ import javax.validation.constraints.Pattern;
 
 public record MemberNickNameCheckReq(
 	@NotBlank(message = "닉네임은 비어있을 수 없습니다.")
-	@Pattern(regexp = "^[a-zA-Z0-9가-힣]+$\n",
+	@Pattern(regexp = "^[a-zA-Z0-9가-힣]+",
 		message = "닉네임은 한글, 알파벳, 숫자만 사용할 수 있습니다.")
 	String nickName
 ) {

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/dto/request/MemberNickNameCheckReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/dto/request/MemberNickNameCheckReq.java
@@ -1,0 +1,13 @@
+package com.palpal.dealightbe.domain.auth.application.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+public record MemberNickNameCheckReq(
+	@NotBlank(message = "닉네임은 비어있을 수 없습니다.")
+	@Pattern(regexp = "^[a-zA-Z0-9가-힣]+$\n",
+		message = "닉네임은 한글, 알파벳, 숫자만 사용할 수 있습니다.")
+	String nickName
+) {
+
+}

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/dto/request/MemberSignupAuthReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/dto/request/MemberSignupAuthReq.java
@@ -19,6 +19,8 @@ public record MemberSignupAuthReq(
 	String realName,
 
 	@NotBlank(message = "닉네임은 필수 입력값입니다.")
+	@Pattern(regexp = "^[a-zA-Z0-9가-힣]+$\n",
+		message = "닉네임은 한글, 알파벳, 숫자만 사용할 수 있습니다.")
 	String nickName,
 
 	@NotBlank(message = "사용자 전화번호는 필수 입력값입니다.")

--- a/src/main/java/com/palpal/dealightbe/domain/auth/application/dto/request/MemberSignupAuthReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/application/dto/request/MemberSignupAuthReq.java
@@ -19,7 +19,7 @@ public record MemberSignupAuthReq(
 	String realName,
 
 	@NotBlank(message = "닉네임은 필수 입력값입니다.")
-	@Pattern(regexp = "^[a-zA-Z0-9가-힣]+$\n",
+	@Pattern(regexp = "^[a-zA-Z0-9가-힣]+",
 		message = "닉네임은 한글, 알파벳, 숫자만 사용할 수 있습니다.")
 	String nickName,
 

--- a/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
@@ -42,7 +42,7 @@ public class AuthController {
 	}
 
 	@PostMapping("/duplicate")
-	public ResponseEntity<Void> checkDuplicateNickName(@Validated MemberNickNameCheckReq request) {
+	public ResponseEntity<Void> checkDuplicateNickName(@RequestBody @Validated MemberNickNameCheckReq request) {
 		authService.checkDuplicateNickName(request);
 
 		return ResponseEntity

--- a/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.palpal.dealightbe.domain.auth.application.AuthService;
 import com.palpal.dealightbe.domain.auth.application.OAuth2AuthorizationService;
+import com.palpal.dealightbe.domain.auth.application.dto.request.MemberNickNameCheckReq;
 import com.palpal.dealightbe.domain.auth.application.dto.request.MemberSignupAuthReq;
 import com.palpal.dealightbe.domain.auth.application.dto.response.MemberAuthRes;
 import com.palpal.dealightbe.domain.auth.application.dto.response.OAuthLoginRes;
@@ -38,6 +39,15 @@ public class AuthController {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(oAuthLoginRes);
+	}
+
+	@GetMapping("/duplicate")
+	public ResponseEntity<Void> checkDuplicateNickName(@Validated MemberNickNameCheckReq request) {
+		authService.checkDuplicateNickName(request);
+
+		return ResponseEntity
+			.noContent()
+			.build();
 	}
 
 	@PostMapping("/signup")

--- a/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/auth/presentation/AuthController.java
@@ -41,7 +41,7 @@ public class AuthController {
 			.body(oAuthLoginRes);
 	}
 
-	@GetMapping("/duplicate")
+	@PostMapping("/duplicate")
 	public ResponseEntity<Void> checkDuplicateNickName(@Validated MemberNickNameCheckReq request) {
 		authService.checkDuplicateNickName(request);
 

--- a/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -43,14 +44,17 @@ public class Member extends BaseEntity {
 	@JoinColumn(name = "address_id")
 	private Address address;
 
+	@Column(nullable = false)
 	private String realName;
 
+	@Column(nullable = false, unique = true)
 	private String nickName;
 
 	private String phoneNumber;
 
 	private String provider;
 
+	@Column(nullable = false, unique = true)
 	private Long providerId;
 
 	private String image;

--- a/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/domain/Member.java
@@ -44,17 +44,14 @@ public class Member extends BaseEntity {
 	@JoinColumn(name = "address_id")
 	private Address address;
 
-	@Column(nullable = false)
 	private String realName;
 
-	@Column(nullable = false, unique = true)
 	private String nickName;
 
 	private String phoneNumber;
 
 	private String provider;
 
-	@Column(nullable = false, unique = true)
 	private Long providerId;
 
 	private String image;

--- a/src/main/java/com/palpal/dealightbe/domain/member/domain/MemberRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/member/domain/MemberRepository.java
@@ -17,4 +17,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 		""")
 	Optional<Member> findByProviderAndProviderId(@Param("provider") String provider,
 		@Param("providerId") Long providerId);
+	
+	boolean existsByNickName(String nickName);
 }

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 
 	//멤버
 	NOT_FOUND_MEMBER("M001", "고객을 찾을 수 없습니다."),
+	DUPLICATED_NICK_NAME("M002", "이미 존재하는 닉네임입니다."),
 
 	//업체
 	INVALID_BUSINESS_TIME("ST001", "마감 시간은 오픈 시간보다 이전일 수 없습니다"),

--- a/src/test/java/com/palpal/dealightbe/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/application/AuthServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import com.palpal.dealightbe.domain.address.domain.Address;
+import com.palpal.dealightbe.domain.auth.application.dto.request.MemberNickNameCheckReq;
 import com.palpal.dealightbe.domain.auth.application.dto.request.MemberSignupAuthReq;
 import com.palpal.dealightbe.domain.auth.application.dto.response.MemberAuthRes;
 import com.palpal.dealightbe.domain.auth.application.dto.response.OAuthLoginRes;
@@ -219,6 +220,19 @@ class AuthServiceTest {
 
 		// when -> then
 		assertThatThrownBy(() -> authService.signup(request))
+			.isInstanceOf(BusinessException.class);
+	}
+
+	@DisplayName("닉네임 중복 검사 실패")
+	@Test
+	void successNickNameDuplicateCheck() {
+		// given
+		MemberNickNameCheckReq request = new MemberNickNameCheckReq("고요송");
+		given(memberRepository.existsByNickName("고요송"))
+			.willReturn(true);
+
+		// when -> then
+		assertThatThrownBy(() -> authService.checkDuplicateNickName(request))
 			.isInstanceOf(BusinessException.class);
 	}
 }

--- a/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/auth/presentation/AuthControllerTest.java
@@ -117,7 +117,7 @@ class AuthControllerTest {
 				.andExpect(status().isBadRequest())
 				.andDo(print())
 				.andDo(document(
-					"auth/auth-duplicate-nickName-check-fail",
+					"auth/auth-duplicate-nickName-check-fail-already-exist",
 					preprocessRequest(prettyPrint()),
 					responseFields(
 						fieldWithPath("timestamp").type(STRING).description("예외 시간"),
@@ -146,7 +146,7 @@ class AuthControllerTest {
 				.andExpect(status().isBadRequest())
 				.andDo(print())
 				.andDo(document(
-					"auth/auth-duplicate-nickName-check-fail",
+					"auth/auth-duplicate-nickName-check-fail-not-valid-form",
 					preprocessRequest(prettyPrint()),
 					responseFields(
 						fieldWithPath("timestamp").type(STRING).description("예외 시간"),


### PR DESCRIPTION
## 💡 관련 이슈

- close: #190

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

수행한 작업을 간단히 요약해주세요.

회원가입시 사용하는 닉네임 중복확인 API를 구현했습니다.
유효성 검사를 통해 특수문자, 공백이 오는 경우는 예외가 발생하도록 했습니다.
관련 API에 관한 Controller 테스트와 Service 테스트를 추가했습니다.

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명

주요 기능/로직 및 작업 내용에 관해 설명해주세요.

/api/auth/duplicate에 Post요청을 할 경우 닉네임 중복검사를 합니다.
이미 존재하는 닉네임, 특수문자, 공백이 오는 경우는 예외가 발생합니다.
그 외의 중복검사에 성공하는 경우에 204 no content로 응답이 옵니다.

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->