### PR TITLE
SSE 알림 기능(이벤트 캐시) 구현 

### DIFF
--- a/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
@@ -50,11 +50,12 @@ public class NotificationService {
 		emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
 
 		emitterRepository.save(emitterId, emitter);
+		String eventId = getEventId(id, userType.getRole());
 
-		sendEventToEmitter(emitter, emitterId, "EventStream Created. [" + userType + "Id=" + id + "]");
+		sendEventToEmitter(emitter, emitterId, eventId, "EventStream Created. [" + userType + "Id=" + id + "]");
 
 		if (!lastEventId.isEmpty()) {
-			resendMissedEvents(id, userType.getRole(), lastEventId, emitter);
+			resendMissedEvents(id, userType.getRole(), emitterId, lastEventId, emitter);
 		}
 
 		return emitter;

--- a/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
@@ -87,13 +87,15 @@ public class NotificationService {
 	}
 
 	private void sendNotification(Long id, Notification notification, String userType) {
-		// userType과 id를 기반으로 emitter를 찾고 이벤트 전송
 		String emitterKeyPrefix = userType + "_" + id;
 
 		Map<String, SseEmitter> emitters = emitterRepository.findAllStartWithById(emitterKeyPrefix);
-		emitters.forEach((key, emitter) -> {
-			emitterRepository.saveEventCache(key, notification);
-			sendEventToEmitter(emitter, key, NotificationRes.from(notification));
+
+		String eventId = getEventId(id, userType);
+		emitterRepository.saveEventCache(eventId, notification);
+
+		emitters.forEach((emitterId, emitter) -> {
+			sendEventToEmitter(emitter, emitterId, eventId, NotificationRes.from(notification));
 		});
 	}
 

--- a/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
@@ -1,5 +1,6 @@
 package com.palpal.dealightbe.domain.notification.application;
 
+import static com.palpal.dealightbe.domain.notification.util.EventIdUtil.extractTimestampFromEventId;
 import static com.palpal.dealightbe.global.error.ErrorCode.SSE_STREAM_ERROR;
 
 import java.io.IOException;
@@ -28,12 +29,15 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class NotificationService {
 	private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
-
 	private final EmitterRepository emitterRepository;
 	private final NotificationRepository notificationRepository;
 
 	private static String getEmitterId(Long id, RoleType userType) {
 		return userType.getRole() + "_" + id + "_" + System.currentTimeMillis();
+	}
+
+	private static String getEventId(Long id, String userType) {
+		return userType + "_" + id + "_" + System.currentTimeMillis();
 	}
 
 	public SseEmitter subscribe(Long id, RoleType userType, String lastEventId) {

--- a/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
@@ -57,7 +57,7 @@ public class NotificationService {
 	}
 
 	private void resendMissedEvents(Long id, String userType, String lastEventId, SseEmitter emitter) {
-		Map<String, Object> events = emitterRepository.findAllEventCacheStartWithId(userType + "_" + id);
+		Map<String, Notification> events = emitterRepository.findAllEventCacheStartWithId(userType + "_" + id);
 		events.entrySet().stream()
 			.filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
 			.forEach(entry -> sendEventToEmitter(emitter, entry.getKey(), entry.getValue()));

--- a/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
@@ -68,16 +68,17 @@ public class NotificationService {
 			.forEach(entry -> sendEventToEmitter(emitter, entry.getKey(), entry.getValue()));
 	}
 
-	private void sendEventToEmitter(SseEmitter emitter, String emitterId, Object data) {
+	private void sendEventToEmitter(SseEmitter emitter, String emitterId, String eventId, Object data) {
 
 		try {
 			if (data instanceof NotificationRes) {
-				// JSON 형태의 객체인 경우
-				emitter.send(SseEmitter.event().id(emitterId).name("orderNotification").data(data));
+				emitter.send(SseEmitter.event()
+					.id(eventId)
+					.name("orderNotification")
+					.data(data));
 			} else {
-				// 문자열인 경우
 				String jsonData = "{\"message\":\"" + data.toString() + "\"}";
-				emitter.send(SseEmitter.event().id(emitterId).name("orderNotification").data(jsonData));
+				emitter.send(SseEmitter.event().id(eventId).name("orderNotification").data(jsonData));
 			}
 		} catch (IOException exception) {
 			emitterRepository.deleteById(emitterId);

--- a/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/application/NotificationService.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.palpal.dealightbe.domain.member.domain.Member;
 import com.palpal.dealightbe.domain.member.domain.RoleType;
+import com.palpal.dealightbe.domain.notification.application.dto.response.NotificationRes;
 import com.palpal.dealightbe.domain.notification.domain.EmitterRepository;
 import com.palpal.dealightbe.domain.notification.domain.Notification;
 import com.palpal.dealightbe.domain.notification.domain.NotificationRepository;
@@ -20,7 +21,9 @@ import com.palpal.dealightbe.domain.store.domain.Store;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
@@ -38,10 +41,12 @@ public class NotificationService {
 		String emitterId = getEmitterId(id, userType);
 
 		SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
-		emitterRepository.save(emitterId, emitter);
 
 		emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
 		emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+
+		emitterRepository.save(emitterId, emitter);
+
 		sendEventToEmitter(emitter, emitterId, "EventStream Created. [" + userType + "Id=" + id + "]");
 
 		if (!lastEventId.isEmpty()) {
@@ -52,19 +57,38 @@ public class NotificationService {
 	}
 
 	private void resendMissedEvents(Long id, String userType, String lastEventId, SseEmitter emitter) {
-		Map<String, String> events = emitterRepository.findAllEventCacheStartWithId(userType + "_" + id);
+		Map<String, Object> events = emitterRepository.findAllEventCacheStartWithId(userType + "_" + id);
 		events.entrySet().stream()
 			.filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
 			.forEach(entry -> sendEventToEmitter(emitter, entry.getKey(), entry.getValue()));
 	}
 
-	private void sendEventToEmitter(SseEmitter emitter, String emitterId, String data) {
+	private void sendEventToEmitter(SseEmitter emitter, String emitterId, Object data) {
+
 		try {
-			emitter.send(SseEmitter.event().id(emitterId).name("orderNotification").data(data));
+			if (data instanceof NotificationRes) {
+				// JSON 형태의 객체인 경우
+				emitter.send(SseEmitter.event().id(emitterId).name("orderNotification").data(data));
+			} else {
+				// 문자열인 경우
+				String jsonData = "{\"message\":\"" + data.toString() + "\"}";
+				emitter.send(SseEmitter.event().id(emitterId).name("orderNotification").data(jsonData));
+			}
 		} catch (IOException exception) {
 			emitterRepository.deleteById(emitterId);
 			throw new BusinessException(SSE_STREAM_ERROR);
 		}
+	}
+
+	private void sendNotification(Long id, Notification notification, String userType) {
+		// userType과 id를 기반으로 emitter를 찾고 이벤트 전송
+		String emitterKeyPrefix = userType + "_" + id;
+
+		Map<String, SseEmitter> emitters = emitterRepository.findAllStartWithById(emitterKeyPrefix);
+		emitters.forEach((key, emitter) -> {
+			emitterRepository.saveEventCache(key, notification);
+			sendEventToEmitter(emitter, key, NotificationRes.from(notification));
+		});
 	}
 
 	@Transactional
@@ -72,48 +96,37 @@ public class NotificationService {
 		// Notification 메시지 생성
 		String message = Notification.createMessage(orderStatus, order);
 
+		// Notification 저장
+		Notification notification = createNotification(member, store, order, message);
+		notificationRepository.save(notification);
+
 		// 알림 대상에 따라 SseEmitter에 이벤트 전송
 		switch (orderStatus) {
-			case RECEIVED:
+			case RECEIVED ->
 				// member가 주문을 했으므로, store에게 알림을 보냄
-				sendNotification(store.getId(), message, "STORE");
-				break;
-			case CONFIRMED:
+				sendNotification(store.getId(), notification, "store");
+			case CONFIRMED ->
 				// store가 주문을 확인했으므로, member에게 알림을 보냄
-				sendNotification(member.getId(), message, "MEMBER");
-				break;
-			case COMPLETED:
+				sendNotification(member.getId(), notification, "member");
+			case COMPLETED -> {
 				// 주문이 완료되었으므로, member와 store 모두에게 알림을 보냄
-				sendNotification(member.getId(), message, "MEMBER");
-				sendNotification(store.getId(), message, "STORE");
-				break;
-			case CANCELED:
-				// 주문이 취소되었으므로, store에게 알림을 보냄
-				sendNotification(store.getId(), message, "STORE");
-				break;
+				sendNotification(member.getId(), notification, "member");
+				sendNotification(store.getId(), notification, "store");
+			}
+			case CANCELED -> {
+				// 주문이 취소되었으므로, member와 store 모두에게 알림을 보냄
+				sendNotification(store.getId(), notification, "store");
+				sendNotification(member.getId(), notification, "member");
+			}
 		}
-
-		// Notification 저장
-		Notification notification = createNotification(member, store, order, orderStatus);
-		notificationRepository.save(notification);
 	}
 
-	private void sendNotification(Long id, String message, String userType) {
-		// userType과 id를 기반으로 emitter를 찾고 이벤트 전송
-		String emitterKeyPrefix = userType + "_" + id;
-		Map<String, SseEmitter> emitters = emitterRepository.findAllStartWithById(emitterKeyPrefix);
-		emitters.forEach((key, emitter) -> {
-			emitterRepository.saveEventCache(key, message);
-			sendEventToEmitter(emitter, key, message);
-		});
-	}
-
-	private Notification createNotification(Member member, Store store, Order order, OrderStatus type) {
+	private Notification createNotification(Member member, Store store, Order order, String content) {
 		return Notification.builder()
 			.member(member)
 			.store(store)
 			.order(order)
-			.type(type)
+			.content(content)
 			.build();
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/notification/application/dto/response/NotificationRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/application/dto/response/NotificationRes.java
@@ -1,0 +1,21 @@
+package com.palpal.dealightbe.domain.notification.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.palpal.dealightbe.domain.notification.domain.Notification;
+
+public record NotificationRes(
+	Long id,
+	String content,
+	LocalDateTime createdAt,
+	boolean isRead
+) {
+	public static NotificationRes from(Notification notification) {
+		return new NotificationRes(
+			notification.getId(),
+			notification.getContent(),
+			notification.getCreatedAt(),
+			notification.isRead()
+		);
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/notification/domain/EmitterRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/domain/EmitterRepository.java
@@ -1,5 +1,7 @@
 package com.palpal.dealightbe.domain.notification.domain;
 
+import static com.palpal.dealightbe.domain.notification.util.EventIdUtil.extractTimestampFromEventId;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -28,9 +30,10 @@ public class EmitterRepository {
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
-	public Map<String, Notification> findAllEventCacheStartWithId(String id) {
+	public Map<String, Notification> findAllEventCacheAfterTimestamp(String prefix, long lastEventTimestamp) {
 		return eventCache.entrySet().stream()
-			.filter(entry -> entry.getKey().startsWith(id))
+			.filter(entry -> entry.getKey().startsWith(prefix))
+			.filter(entry -> extractTimestampFromEventId(entry.getKey()) > lastEventTimestamp)
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 

--- a/src/main/java/com/palpal/dealightbe/domain/notification/domain/EmitterRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/domain/EmitterRepository.java
@@ -11,14 +11,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class EmitterRepository {
 
 	public final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
-	private final Map<String, String> eventCache = new ConcurrentHashMap<>();
+	private final Map<String, Notification> eventCache = new ConcurrentHashMap<>();
 
 	public SseEmitter save(String id, SseEmitter sseEmitter) {
 		emitters.put(id, sseEmitter);
 		return sseEmitter;
 	}
 
-	public void saveEventCache(String id, String event) {
+	public void saveEventCache(String id, Notification event) {
 		eventCache.put(id, event);
 	}
 
@@ -28,7 +28,7 @@ public class EmitterRepository {
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
-	public Map<String, String> findAllEventCacheStartWithId(String id) {
+	public Map<String, Notification> findAllEventCacheStartWithId(String id) {
 		return eventCache.entrySet().stream()
 			.filter(entry -> entry.getKey().startsWith(id))
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
@@ -42,7 +42,6 @@ public class Notification extends BaseEntity {
 	@JoinColumn(name = "order_id")
 	private Order order;
 
-	// @Enumerated(EnumType.STRING)
 	private String content;
 
 	private boolean isRead = false;

--- a/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/domain/Notification.java
@@ -1,8 +1,6 @@
 package com.palpal.dealightbe.domain.notification.domain;
 
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -16,8 +14,6 @@ import com.palpal.dealightbe.domain.order.domain.Order;
 import com.palpal.dealightbe.domain.order.domain.OrderStatus;
 import com.palpal.dealightbe.domain.store.domain.Store;
 import com.palpal.dealightbe.global.BaseEntity;
-import com.palpal.dealightbe.global.error.ErrorCode;
-import com.palpal.dealightbe.global.error.exception.BusinessException;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -46,17 +42,17 @@ public class Notification extends BaseEntity {
 	@JoinColumn(name = "order_id")
 	private Order order;
 
-	@Enumerated(EnumType.STRING)
-	private OrderStatus type;
+	// @Enumerated(EnumType.STRING)
+	private String content;
 
 	private boolean isRead = false;
 
 	@Builder
-	public Notification(Member member, Store store, Order order, OrderStatus type) {
+	public Notification(Member member, Store store, Order order, String content) {
 		this.member = member;
 		this.store = store;
 		this.order = order;
-		this.type = type;
+		this.content = content;
 	}
 
 	public void markAsRead() {
@@ -64,17 +60,6 @@ public class Notification extends BaseEntity {
 	}
 
 	public static String createMessage(OrderStatus orderStatus, Order order) {
-		switch (orderStatus) {
-			case RECEIVED:
-				return "새 주문이 도착했습니다: " + order.getId();
-			case CONFIRMED:
-				return "주문이 수락되었습니다: " + order.getId();
-			case COMPLETED:
-				return "주문이 완료되었습니다: " + order.getId();
-			case CANCELED:
-				return "주문이 취소되었습니다: " + order.getId();
-			default:
-				throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
-		}
+		return orderStatus.createMessage(order.getId());
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/notification/util/EventIdUtil.java
+++ b/src/main/java/com/palpal/dealightbe/domain/notification/util/EventIdUtil.java
@@ -1,0 +1,12 @@
+package com.palpal.dealightbe.domain.notification.util;
+
+public final class EventIdUtil {
+
+	private EventIdUtil() {
+	}
+
+	public static long extractTimestampFromEventId(String eventId) {
+		String[] parts = eventId.split("_");
+		return Long.parseLong(parts[parts.length - 1]);
+	}
+}


### PR DESCRIPTION
## 💡 관련 이슈

- close: (https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-BE/issues/171)

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

수행한 작업을 간단히 요약해주세요.

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

- SSE 알림 기능 중 이벤트를 캐시에 저장하고 발송하는 로직을 추가했습니다.

## 🔎 작업 상세 설명

주요 기능/로직 및 작업 내용에 관해 설명해주세요.
- SSE 연결이후 서버와 클라이언트 사이 서버에서 설정한 DEFAULT_TIMEOUT 동안 아무런 데이터가 전송되지 않으면, 연결이 닫힙니다. (현재 60분으로 설정해두었습니다)
- 사용자가 서버로부터 알림 스트림을 수신하는 동안, 각 알림 이벤트의 ID를 'Last-Event-ID' 헤더에 저장하여, SSE 연결이 끊긴 후 자동 재연결 시 서버에 마지막으로 수신한 이벤트 ID를 보내어 이를 유실된 알림을 받아보는데 활용할 수 있게끔 각 event를 캐쉬에 저장합니다.
- 서버는 수신된 'Last-Event-ID' 와 캐시에 저장된 eventId의 usertype, id, timestamp를 비교해 해당 유저에게 미발송된 알림이 있다면 재전송합니다. 
- 캐시에 저장된 event 삭제 및 읽음 처리 기능은 이어서 구현할 예정입니다.

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->