### PR TITLE
hotfix: ItemController lastId 제거, dto 네이밍 변경

### DIFF
--- a/src/docs/asciidoc/Item.adoc
+++ b/src/docs/asciidoc/Item.adoc
@@ -119,9 +119,7 @@ include::{snippets}/item/item-find-by-id-fail-not-found-item/response-fields.ado
 
 === 상품 목록 조회(업체 시점)
 
-==== /api/items/stores?last-id={lastId}&size={size}&page={page}
-
-- 첫 페이지 조회 시 last-id는 쿼리스트링에 삽입하지 않음
+==== /api/items/stores?size={size}&page={page}
 
 .Request Success - 성공
 include::{snippets}/item/item-find-all-for-store/http-request.adoc[]
@@ -141,9 +139,7 @@ include::{snippets}/item/item-find-all-for-store/response-fields.adoc[]
 
 === 상품 목록 조회(고객 시점)
 
-==== /api/items/members?x-coordinate={xCoordinate}&y-coordinate={yCoordinate}&sort-by={sortBy}&last-id={lastId}&size={size}&page={page}
-
-- 첫 페이지 조회 시 last-id는 쿼리스트링에 삽입하지 않음
+==== /api/items/members?x-coordinate={xCoordinate}&y-coordinate={yCoordinate}&sort-by={sortBy}&size={size}&page={page}
 
 <sort-by(정렬 조건) 종류>
 
@@ -165,9 +161,7 @@ include::{snippets}/item/item-find-all-for-member/response-fields.adoc[]
 
 === 업체의 상품 목록 조회(고객 시점)
 
-==== /api/items/stores/{storeId}?last-id={lastId}&size={size}&page={page}
-
-- 첫 페이지 조회 시 last-id는 쿼리스트링에 삽입하지 않음
+==== /api/items/stores/{storeId}?size={size}&page={page}
 
 .Request Success - 성공
 include::{snippets}/item/item-find-all-by-store-id/http-request.adoc[]

--- a/src/main/java/com/palpal/dealightbe/domain/item/application/ItemService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/application/ItemService.java
@@ -42,7 +42,7 @@ public class ItemService {
 	public ItemRes create(ItemReq itemReq, Long providerId, ImageUploadReq imageUploadReq) {
 		Store store = getStore(providerId);
 
-		checkDuplicatedItemName(itemReq.name(), store.getId());
+		checkDuplicatedItemName(itemReq.itemName(), store.getId());
 
 		String imageUrl = saveImage(imageUploadReq);
 
@@ -94,7 +94,7 @@ public class ItemService {
 		Store store = getStore(providerId);
 		Item item = getItem(itemId);
 
-		checkDuplicatedItemNameForUpdate(itemId, itemReq.name(), store.getId());
+		checkDuplicatedItemNameForUpdate(itemId, itemReq.itemName(), store.getId());
 
 		String image = item.getImage();
 		imageService.delete(image);

--- a/src/main/java/com/palpal/dealightbe/domain/item/application/dto/request/ItemReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/application/dto/request/ItemReq.java
@@ -11,7 +11,7 @@ import com.palpal.dealightbe.domain.store.domain.Store;
 public record ItemReq(
 	@NotBlank(message = "상품 이름을 입력해주세요.")
 	@Length(min = 1, max = 50, message = "상품 이름은 1자 이상 50자 이하로 등록 가능합니다.")
-	String name,
+	String itemName,
 
 	@Min(value = 1, message = "상품 재고 수량은 1개 이상부터 등록 가능합니다.")
 	int stock,
@@ -32,7 +32,7 @@ public record ItemReq(
 	public static Item toItem(ItemReq itemReq, Store store, String image) {
 
 		return Item.builder()
-			.name(itemReq.name)
+			.name(itemReq.itemName)
 			.stock(itemReq.stock)
 			.discountPrice(itemReq.discountPrice)
 			.originalPrice(itemReq.originalPrice)

--- a/src/main/java/com/palpal/dealightbe/domain/item/presentation/ItemController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/presentation/ItemController.java
@@ -51,7 +51,7 @@ public class ItemController {
 
 	@ProviderId
 	@GetMapping("/stores")
-	public ResponseEntity<ItemsRes> findAllForStore(Long providerId, @RequestParam(name = "last-id", required = false) Long lastId, @RequestParam(required = false, defaultValue = "0") int page, @RequestParam(required = false, defaultValue = DEFAULT_PAGE_SIZE) int size) {
+	public ResponseEntity<ItemsRes> findAllForStore(Long providerId, @RequestParam(required = false, defaultValue = "0") int page, @RequestParam(required = false, defaultValue = DEFAULT_PAGE_SIZE) int size) {
 		page = Math.max(page - 1, 0);
 		PageRequest pageable = PageRequest.of(page, size);
 
@@ -61,7 +61,7 @@ public class ItemController {
 	}
 
 	@GetMapping("/members")
-	public ResponseEntity<ItemsRes> findAllForMember(@RequestParam("x-coordinate") double xCoordinate, @RequestParam("y-coordinate") double yCoordinate, @RequestParam(value = "sort-by", required = false, defaultValue = "distance") String sortBy, @RequestParam(name = "last-id", required = false) Long lastId, @RequestParam(required = false, defaultValue = "0") int page, @RequestParam(required = false, defaultValue = DEFAULT_PAGE_SIZE) int size) {
+	public ResponseEntity<ItemsRes> findAllForMember(@RequestParam("x-coordinate") double xCoordinate, @RequestParam("y-coordinate") double yCoordinate, @RequestParam(value = "sort-by", required = false, defaultValue = "distance") String sortBy, @RequestParam(required = false, defaultValue = "0") int page, @RequestParam(required = false, defaultValue = DEFAULT_PAGE_SIZE) int size) {
 		page = Math.max(page - 1, 0);
 		PageRequest pageable = PageRequest.of(page, size);
 
@@ -71,7 +71,7 @@ public class ItemController {
 	}
 
 	@GetMapping("/stores/{storeId}")
-	public ResponseEntity<ItemsRes> findAllByStoreId(@PathVariable Long storeId, @RequestParam(name = "last-id", required = false) Long lastId, @RequestParam(required = false, defaultValue = "0") int page, @RequestParam(required = false, defaultValue = DEFAULT_PAGE_SIZE) int size) {
+	public ResponseEntity<ItemsRes> findAllByStoreId(@PathVariable Long storeId, @RequestParam(required = false, defaultValue = "0") int page, @RequestParam(required = false, defaultValue = DEFAULT_PAGE_SIZE) int size) {
 		page = Math.max(page - 1, 0);
 		PageRequest pageable = PageRequest.of(page, size);
 

--- a/src/test/java/com/palpal/dealightbe/domain/item/application/ItemServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/item/application/ItemServiceTest.java
@@ -391,7 +391,7 @@ class ItemServiceTest {
 		ItemRes itemRes = itemService.update(itemId, itemReq, providerId, imageUploadReq);
 
 		//then
-		assertThat(itemRes.itemName()).isEqualTo(itemReq.name());
+		assertThat(itemRes.itemName()).isEqualTo(itemReq.itemName());
 		assertThat(itemRes.stock()).isEqualTo(itemReq.stock());
 		assertThat(itemRes.discountPrice()).isEqualTo(itemReq.discountPrice());
 		assertThat(itemRes.originalPrice()).isEqualTo(itemReq.originalPrice());

--- a/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
@@ -51,7 +51,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.operation.preprocess.Preprocessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 
@@ -210,7 +209,7 @@ class ItemControllerTest {
 					partWithName("itemReq").description("상품 등록 내용")
 				),
 				requestPartFields("itemReq",
-					fieldWithPath("name").type(STRING).description("상품 이름"),
+					fieldWithPath("itemName").type(STRING).description("상품 이름"),
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
@@ -276,10 +275,10 @@ class ItemControllerTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.timestamp").isNotEmpty())
 			.andExpect(jsonPath("$.code").value("C001"))
-			.andExpect(jsonPath("$.errors[0].field").value("name"))
+			.andExpect(jsonPath("$.errors[0].field").value("itemName"))
 			.andExpect(jsonPath("$.errors[0].value").value(""))
 			.andExpect(jsonPath("$.errors[0].reason").isNotEmpty())
-			.andExpect(jsonPath("$.errors[1].field").value("name"))
+			.andExpect(jsonPath("$.errors[1].field").value("itemName"))
 			.andExpect(jsonPath("$.errors[1].value").value(""))
 			.andExpect(jsonPath("$.errors[1].reason").isNotEmpty())
 			.andExpect(jsonPath("$.message").value("잘못된 값을 입력하셨습니다."))
@@ -295,7 +294,7 @@ class ItemControllerTest {
 					partWithName("itemReq").description("상품 등록 내용")
 				),
 				requestPartFields("itemReq",
-					fieldWithPath("name").type(STRING).description("상품 이름"),
+					fieldWithPath("itemName").type(STRING).description("상품 이름"),
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
@@ -353,7 +352,7 @@ class ItemControllerTest {
 					partWithName("itemReq").description("상품 등록 내용")
 				),
 				requestPartFields("itemReq",
-					fieldWithPath("name").type(STRING).description("상품 이름"),
+					fieldWithPath("itemName").type(STRING).description("상품 이름"),
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
@@ -408,7 +407,7 @@ class ItemControllerTest {
 					partWithName("itemReq").description("상품 등록 내용")
 				),
 				requestPartFields("itemReq",
-					fieldWithPath("name").type(STRING).description("상품 이름"),
+					fieldWithPath("itemName").type(STRING).description("상품 이름"),
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
@@ -523,8 +522,6 @@ class ItemControllerTest {
 			.store(store)
 			.build();
 
-		Long lastId = 0L;
-
 		int size = 5;
 		int page = 0;
 		PageRequest pageRequest = PageRequest.of(page, size);
@@ -544,7 +541,6 @@ class ItemControllerTest {
 		mockMvc.perform(RestDocumentationRequestBuilders.get("/api/items/stores")
 				.contentType(MediaType.APPLICATION_JSON)
 				.header("Authorization", "Bearer {ACCESS_TOKEN}")
-				.param("last-id", String.valueOf(lastId))
 				.param("size", String.valueOf(size))
 				.param("page", String.valueOf(1)))
 			.andExpect(status().isOk())
@@ -573,7 +569,6 @@ class ItemControllerTest {
 				),
 				requestParameters(
 					List.of(
-						parameterWithName("last-id").description("이전 페이지 목록의 마지막 상품 ID"),
 						parameterWithName("size").description("한 페이지 당 상품 목록 개수"),
 						parameterWithName("page").description("페이지 번호")
 					)),
@@ -607,8 +602,6 @@ class ItemControllerTest {
 		double yCoordinate = 37.5912999;
 		String sortBy = "deadline";
 
-		Long lastId = 0L;
-
 		int size = 5;
 		int page = 0;
 		PageRequest pageRequest = PageRequest.of(page, size);
@@ -631,7 +624,6 @@ class ItemControllerTest {
 				.param("x-coordinate", String.valueOf(xCoordinate))
 				.param("y-coordinate", String.valueOf(yCoordinate))
 				.param("sort-by", sortBy)
-				.param("last-id", String.valueOf(lastId))
 				.param("size", String.valueOf(size))
 				.param("page", String.valueOf(1)))
 			.andExpect(status().isOk())
@@ -659,7 +651,6 @@ class ItemControllerTest {
 					List.of(parameterWithName("x-coordinate").description("경도"),
 						parameterWithName("y-coordinate").description("위도"),
 						parameterWithName("sort-by").description("정렬 기준"),
-						parameterWithName("last-id").description("이전 페이지 목록의 마지막 상품 ID"),
 						parameterWithName("size").description("한 페이지 당 상품 목록 개수"),
 						parameterWithName("page").description("페이지 번호")
 					)),
@@ -702,8 +693,6 @@ class ItemControllerTest {
 			.store(store)
 			.build();
 
-		Long lastId = 0L;
-
 		int size = 5;
 		int page = 0;
 		PageRequest pageRequest = PageRequest.of(page, size);
@@ -722,7 +711,6 @@ class ItemControllerTest {
 		//then
 		mockMvc.perform(RestDocumentationRequestBuilders.get("/api/items/stores/{storeId}", storeId)
 				.contentType(MediaType.APPLICATION_JSON)
-				.param("last-id", String.valueOf(lastId))
 				.param("size", String.valueOf(size))
 				.param("page", String.valueOf(1)))
 			.andExpect(status().isOk())
@@ -751,7 +739,6 @@ class ItemControllerTest {
 				),
 				requestParameters(
 					List.of(
-						parameterWithName("last-id").description("이전 페이지 목록의 마지막 상품 ID"),
 						parameterWithName("size").description("한 페이지 당 상품 목록 개수"),
 						parameterWithName("page").description("페이지 번호")
 					)),
@@ -787,7 +774,7 @@ class ItemControllerTest {
 		String imageUrl = "http://image-url.com/image.jpg";
 
 		ItemReq itemReq = new ItemReq("치즈 떡볶이", 4, 9900, 14000, "치즈 떡볶이 입니다.", "통신사 할인 가능 합니다.");
-		ItemRes itemRes = new ItemRes(itemId, 1L, itemReq.name(), itemReq.stock(), itemReq.discountPrice(),
+		ItemRes itemRes = new ItemRes(itemId, 1L, itemReq.itemName(), itemReq.stock(), itemReq.discountPrice(),
 			itemReq.originalPrice(), itemReq.description(), itemReq.information(), imageUrl, store.getName(), store.getOpenTime(), store.getCloseTime(), addressRes);
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
@@ -842,7 +829,7 @@ class ItemControllerTest {
 					partWithName("itemReq").description("상품 등록 내용")
 				),
 				requestPartFields("itemReq",
-					fieldWithPath("name").type(STRING).description("상품 이름"),
+					fieldWithPath("itemName").type(STRING).description("상품 이름"),
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
@@ -920,10 +907,10 @@ class ItemControllerTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.timestamp").isNotEmpty())
 			.andExpect(jsonPath("$.code").value("C001"))
-			.andExpect(jsonPath("$.errors[0].field").value("name"))
+			.andExpect(jsonPath("$.errors[0].field").value("itemName"))
 			.andExpect(jsonPath("$.errors[0].value").value(""))
 			.andExpect(jsonPath("$.errors[0].reason").isNotEmpty())
-			.andExpect(jsonPath("$.errors[1].field").value("name"))
+			.andExpect(jsonPath("$.errors[1].field").value("itemName"))
 			.andExpect(jsonPath("$.errors[1].value").value(""))
 			.andExpect(jsonPath("$.errors[1].reason").isNotEmpty())
 			.andExpect(jsonPath("$.message").value("잘못된 값을 입력하셨습니다."))
@@ -940,7 +927,7 @@ class ItemControllerTest {
 					partWithName("itemReq").description("상품 등록 내용")
 				),
 				requestPartFields("itemReq",
-					fieldWithPath("name").type(STRING).description("상품 이름"),
+					fieldWithPath("itemName").type(STRING).description("상품 이름"),
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
@@ -1009,7 +996,7 @@ class ItemControllerTest {
 					partWithName("itemReq").description("상품 등록 내용")
 				),
 				requestPartFields("itemReq",
-					fieldWithPath("name").type(STRING).description("상품 이름"),
+					fieldWithPath("itemName").type(STRING).description("상품 이름"),
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
@@ -1088,7 +1075,7 @@ class ItemControllerTest {
 					partWithName("itemReq").description("상품 등록 내용")
 				),
 				requestPartFields("itemReq",
-					fieldWithPath("name").type(STRING).description("상품 이름"),
+					fieldWithPath("itemName").type(STRING).description("상품 이름"),
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),


### PR DESCRIPTION
## 💡 관련 이슈

- close: #217 

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약
- ItemController lastId 제거
- dto 네이밍 변경

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명
- 상황 상 no offset 기능을 적용하기 어려울 것 같아 lastId변수를 ItemController에서 제거했습니다.
- 프론트 측의 요청으로 ItemReq의 상품 이름 필드를 name에서 itemName으로 수정했습니다.

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->