### PR TITLE
hotfix: Item 필드, Item Response 수정

### DIFF
--- a/src/main/java/com/palpal/dealightbe/domain/item/application/dto/request/ItemReq.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/application/dto/request/ItemReq.java
@@ -23,10 +23,7 @@ public record ItemReq(
 	int originalPrice,
 
 	@Length(max = 300, message = "상품 설명은 300자 이하로 등록 가능합니다.")
-	String description,
-
-	@Length(max = 300, message = "상품 안내 사항은 300자 이하로 등록 가능합니다.")
-	String information
+	String description
 ) {
 
 	public static Item toItem(ItemReq itemReq, Store store, String image) {
@@ -37,7 +34,6 @@ public record ItemReq(
 			.discountPrice(itemReq.discountPrice)
 			.originalPrice(itemReq.originalPrice)
 			.description(itemReq.description)
-			.information(itemReq.information)
 			.image(image)
 			.store(store)
 			.build();

--- a/src/main/java/com/palpal/dealightbe/domain/item/application/dto/response/ItemRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/application/dto/response/ItemRes.java
@@ -14,7 +14,6 @@ public record ItemRes(
 	int discountPrice,
 	int originalPrice,
 	String description,
-	String information,
 	String image,
 	String storeName,
 
@@ -34,7 +33,6 @@ public record ItemRes(
 			item.getDiscountPrice(),
 			item.getOriginalPrice(),
 			item.getDescription(),
-			item.getInformation(),
 			item.getImage(),
 			item.getStore().getName(),
 			item.getStore().getCloseTime(),

--- a/src/main/java/com/palpal/dealightbe/domain/item/application/dto/response/ItemRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/application/dto/response/ItemRes.java
@@ -19,9 +19,6 @@ public record ItemRes(
 	String storeName,
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-	LocalTime storeOpenTime,
-
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
 	LocalTime storeCloseTime,
 
 	AddressRes storeAddress
@@ -40,7 +37,6 @@ public record ItemRes(
 			item.getInformation(),
 			item.getImage(),
 			item.getStore().getName(),
-			item.getStore().getOpenTime(),
 			item.getStore().getCloseTime(),
 			AddressRes.from(item.getStore().getAddress())
 		);

--- a/src/main/java/com/palpal/dealightbe/domain/item/domain/Item.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/domain/Item.java
@@ -48,9 +48,6 @@ public class Item extends BaseEntity {
 	@Column(length = 300)
 	private String description;
 
-	@Column(length = 300)
-	private String information;
-
 	private String image;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -58,8 +55,7 @@ public class Item extends BaseEntity {
 	private Store store;
 
 	@Builder
-	public Item(String name, int stock, int discountPrice, int originalPrice, String description, String information,
-				String image, Store store) {
+	public Item(String name, int stock, int discountPrice, int originalPrice, String description, String image, Store store) {
 		validateDiscountPrice(discountPrice, originalPrice);
 
 		this.name = name;
@@ -67,7 +63,6 @@ public class Item extends BaseEntity {
 		this.discountPrice = discountPrice;
 		this.originalPrice = originalPrice;
 		this.description = description;
-		this.information = information;
 		this.image = image;
 		this.store = store;
 	}
@@ -88,7 +83,6 @@ public class Item extends BaseEntity {
 		this.discountPrice = item.getDiscountPrice();
 		this.originalPrice = item.getOriginalPrice();
 		this.description = item.getDescription();
-		this.information = item.getInformation();
 		this.image = item.getImage();
 	}
 

--- a/src/test/java/com/palpal/dealightbe/domain/cart/presentation/CartControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/cart/presentation/CartControllerTest.java
@@ -113,7 +113,6 @@ class CartControllerTest {
 			.discountPrice(3000)
 			.originalPrice(4500)
 			.description("기본 떡볶이 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store)
 			.build();
@@ -124,7 +123,6 @@ class CartControllerTest {
 			.discountPrice(4000)
 			.originalPrice(4500)
 			.description("김밥 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item2.png")
 			.store(store)
 			.build();

--- a/src/test/java/com/palpal/dealightbe/domain/item/application/ItemServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/item/application/ItemServiceTest.java
@@ -87,7 +87,6 @@ class ItemServiceTest {
 			.discountPrice(3000)
 			.originalPrice(4500)
 			.description("기본 떡볶이 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store)
 			.build();
@@ -113,7 +112,6 @@ class ItemServiceTest {
 			.discountPrice(4000)
 			.originalPrice(4500)
 			.description("김밥 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item2.png")
 			.store(store2)
 			.build();
@@ -123,7 +121,7 @@ class ItemServiceTest {
 	@Test
 	void itemCreateSuccessTest() {
 		//given
-		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation());
+		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription());
 		Long providerId = 1L;
 
 		MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "Spring Framework".getBytes());
@@ -144,7 +142,6 @@ class ItemServiceTest {
 		assertThat(itemRes.discountPrice()).isEqualTo(item.getDiscountPrice());
 		assertThat(itemRes.originalPrice()).isEqualTo(item.getOriginalPrice());
 		assertThat(itemRes.description()).isEqualTo(item.getDescription());
-		assertThat(itemRes.information()).isEqualTo(item.getInformation());
 		assertThat(itemRes.image()).isEqualTo(item.getImage());
 	}
 
@@ -152,7 +149,7 @@ class ItemServiceTest {
 	@Test
 	void itemCreateFailureTest_storeNotFound() {
 		//given
-		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation());
+		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription());
 		Long providerId = 1L;
 
 		MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "Spring Framework".getBytes());
@@ -171,7 +168,7 @@ class ItemServiceTest {
 	@Test
 	void itemCreateFailureTest_invalidDiscountPrice() {
 		//given
-		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), 4500, 4000, item.getDescription(), item.getInformation());
+		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), 4500, 4000, item.getDescription());
 		Long providerId = 1L;
 
 		MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "Spring Framework".getBytes());
@@ -203,7 +200,6 @@ class ItemServiceTest {
 		assertThat(itemRes.discountPrice()).isEqualTo(item.getDiscountPrice());
 		assertThat(itemRes.originalPrice()).isEqualTo(item.getOriginalPrice());
 		assertThat(itemRes.description()).isEqualTo(item.getDescription());
-		assertThat(itemRes.information()).isEqualTo(item.getInformation());
 	}
 
 	@DisplayName("상품 상세 정보 조회(단건) 실패 테스트 - 상품이 존재하지 않는 경우")
@@ -230,7 +226,6 @@ class ItemServiceTest {
 			.discountPrice(4000)
 			.originalPrice(4500)
 			.description("치즈 김밥 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item2.png")
 			.store(store)
 			.build();
@@ -345,7 +340,6 @@ class ItemServiceTest {
 			.discountPrice(4000)
 			.originalPrice(4500)
 			.description("치즈 김밥 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item2.png")
 			.store(store)
 			.build();
@@ -375,7 +369,7 @@ class ItemServiceTest {
 	@Test
 	void itemUpdateSuccessTest() {
 		//given
-		ItemReq itemReq = new ItemReq("수정이름", 1, 3000, 3500, "상세 내용 수정", "안내 사항 수정");
+		ItemReq itemReq = new ItemReq("수정이름", 1, 3000, 3500, "상세 내용 수정");
 		Long providerId = 1L;
 		Long itemId = 1L;
 
@@ -396,7 +390,6 @@ class ItemServiceTest {
 		assertThat(itemRes.discountPrice()).isEqualTo(itemReq.discountPrice());
 		assertThat(itemRes.originalPrice()).isEqualTo(itemReq.originalPrice());
 		assertThat(itemRes.description()).isEqualTo(itemReq.description());
-		assertThat(itemRes.information()).isEqualTo(itemReq.information());
 		assertThat(itemRes.image()).isEqualTo(imageUrl);
 	}
 
@@ -404,7 +397,7 @@ class ItemServiceTest {
 	@Test
 	void itemUpdateFailureTest_invalidDiscountPrice() {
 		//given
-		ItemReq itemReq = new ItemReq("수정이름", 1, 4000, 3500, "상세 내용 수정", "안내 사항 수정");
+		ItemReq itemReq = new ItemReq("수정이름", 1, 4000, 3500, "상세 내용 수정");
 		Long providerId = 1L;
 		Long itemId = 1L;
 

--- a/src/test/java/com/palpal/dealightbe/domain/item/domain/ItemRepositoryTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/item/domain/ItemRepositoryTest.java
@@ -12,14 +12,12 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.palpal.dealightbe.config.JpaConfig;
 import com.palpal.dealightbe.domain.address.domain.Address;
@@ -92,7 +90,6 @@ class ItemRepositoryTest {
 			.discountPrice(3300)
 			.originalPrice(4800)
 			.description("기본 떡볶이 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store1)
 			.build();
@@ -115,7 +112,6 @@ class ItemRepositoryTest {
 			.discountPrice(3000)
 			.originalPrice(3300)
 			.description("치즈 떡볶이 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store2)
 			.build();
@@ -138,7 +134,6 @@ class ItemRepositoryTest {
 			.discountPrice(1000)
 			.originalPrice(2500)
 			.description("순대 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store3)
 			.build();
@@ -161,7 +156,6 @@ class ItemRepositoryTest {
 			.discountPrice(2010)
 			.originalPrice(4800)
 			.description("찹쌀 순대 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store4)
 			.build();
@@ -184,7 +178,6 @@ class ItemRepositoryTest {
 			.discountPrice(2400)
 			.originalPrice(4550)
 			.description("김밥 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store5)
 			.build();
@@ -207,7 +200,6 @@ class ItemRepositoryTest {
 			.discountPrice(3500)
 			.originalPrice(4900)
 			.description("김밥 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store6)
 			.build();

--- a/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
@@ -164,7 +164,7 @@ class ItemControllerTest {
 
 		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(),
 			item.getDescription(), item.getInformation());
-		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getOpenTime(), item.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -192,7 +192,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.information").value(itemRes.information()))
 			.andExpect(jsonPath("$.image").value(itemRes.image()))
 			.andExpect(jsonPath("$.storeName").value(itemRes.storeName()))
-			.andExpect(jsonPath("$.storeOpenTime").value(itemRes.storeOpenTime().toString()))
 			.andExpect(jsonPath("$.storeCloseTime").value(itemRes.storeCloseTime().toString()))
 			.andExpect(jsonPath("$.storeAddress.name").value(addressRes.name()))
 			.andExpect(jsonPath("$.storeAddress.xCoordinate").value(addressRes.xCoordinate()))
@@ -227,7 +226,6 @@ class ItemControllerTest {
 					fieldWithPath("information").type(STRING).description("안내 사항"),
 					fieldWithPath("image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("storeName").type(STRING).description("상호명"),
-					fieldWithPath("storeOpenTime").type(STRING).description("오픈 시간"),
 					fieldWithPath("storeCloseTime").type(STRING).description("마감 시간"),
 					fieldWithPath("storeAddress.name").type(STRING).description("업체 주소"),
 					fieldWithPath("storeAddress.xCoordinate").type(NUMBER).description("업체 주소 경도"),
@@ -254,7 +252,7 @@ class ItemControllerTest {
 
 		ItemReq itemReq = new ItemReq(item2.getName(), item2.getStock(), item2.getDiscountPrice(),
 			item2.getOriginalPrice(), item2.getDescription(), item2.getInformation());
-		ItemRes itemRes = new ItemRes(1L, 1L, item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage(), item2.getStore().getName(), item2.getStore().getOpenTime(), item2.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes = new ItemRes(1L, 1L, item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage(), item2.getStore().getName(), item2.getStore().getCloseTime(), addressRes);
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -431,7 +429,7 @@ class ItemControllerTest {
 
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 
-		ItemRes itemRes = new ItemRes(itemId, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getName(), item.getStore().getOpenTime(), item.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes = new ItemRes(itemId, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getName(), item.getStore().getCloseTime(), addressRes);
 
 		when(itemService.findById(any())).thenReturn(itemRes);
 
@@ -450,7 +448,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.information").value(itemRes.information()))
 			.andExpect(jsonPath("$.image").value(itemRes.image()))
 			.andExpect(jsonPath("$.storeName").value(itemRes.storeName()))
-			.andExpect(jsonPath("$.storeOpenTime").value(itemRes.storeOpenTime().toString()))
 			.andExpect(jsonPath("$.storeCloseTime").value(itemRes.storeCloseTime().toString()))
 			.andExpect(jsonPath("$.storeAddress.name").value(addressRes.name()))
 			.andExpect(jsonPath("$.storeAddress.xCoordinate").value(addressRes.xCoordinate()))
@@ -471,7 +468,6 @@ class ItemControllerTest {
 					fieldWithPath("information").type(STRING).description("안내 사항"),
 					fieldWithPath("image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("storeName").type(STRING).description("상호명"),
-					fieldWithPath("storeOpenTime").type(STRING).description("오픈 시간"),
 					fieldWithPath("storeCloseTime").type(STRING).description("마감 시간"),
 					fieldWithPath("storeAddress.name").type(STRING).description("업체 주소"),
 					fieldWithPath("storeAddress.xCoordinate").type(NUMBER).description("업체 주소 경도"),
@@ -528,8 +524,8 @@ class ItemControllerTest {
 
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 
-		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getOpenTime(), item.getStore().getCloseTime(), addressRes);
-		ItemRes itemRes3 = new ItemRes(2L, 1L, item3.getName(), item3.getStock(), item3.getDiscountPrice(), item3.getOriginalPrice(), item3.getDescription(), item3.getInformation(), item3.getImage(), item3.getStore().getName(), item3.getStore().getOpenTime(), item3.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes3 = new ItemRes(2L, 1L, item3.getName(), item3.getStock(), item3.getDiscountPrice(), item3.getOriginalPrice(), item3.getDescription(), item3.getInformation(), item3.getImage(), item3.getStore().getName(), item3.getStore().getCloseTime(), addressRes);
 		List<ItemRes> itemResList = List.of(itemRes, itemRes3);
 		boolean hasNext = false;
 		ItemsRes itemsRes = new ItemsRes(itemResList, hasNext);
@@ -554,7 +550,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.items[0].information").value(itemRes.information()))
 			.andExpect(jsonPath("$.items[0].image").value(itemRes.image()))
 			.andExpect(jsonPath("$.items[0].storeName").value(itemRes.storeName()))
-			.andExpect(jsonPath("$.items[0].storeOpenTime").value(itemRes.storeOpenTime().toString()))
 			.andExpect(jsonPath("$.items[0].storeCloseTime").value(itemRes.storeCloseTime().toString()))
 			.andExpect(jsonPath("$.items[0].storeAddress.name").value(addressRes.name()))
 			.andExpect(jsonPath("$.items[0].storeAddress.xCoordinate").value(addressRes.xCoordinate()))
@@ -584,7 +579,6 @@ class ItemControllerTest {
 					fieldWithPath("items[0].information").type(STRING).description("안내 사항"),
 					fieldWithPath("items[0].image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("items[0].storeName").type(STRING).description("상호명"),
-					fieldWithPath("items[0].storeOpenTime").type(STRING).description("오픈 시간"),
 					fieldWithPath("items[0].storeCloseTime").type(STRING).description("마감 시간"),
 					fieldWithPath("items[0].storeAddress.name").type(STRING).description("업체 주소"),
 					fieldWithPath("items[0].storeAddress.xCoordinate").type(NUMBER).description("업체 주소 경도"),
@@ -609,8 +603,8 @@ class ItemControllerTest {
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 		AddressRes addressRes2 = new AddressRes(address2.getName(), address2.getXCoordinate(), address2.getYCoordinate());
 
-		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getOpenTime(), item.getStore().getCloseTime(), addressRes);
-		ItemRes itemRes2 = new ItemRes(2L, 2L, item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage(), item2.getStore().getName(), item2.getStore().getOpenTime(), item2.getStore().getCloseTime(), addressRes2);
+		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes2 = new ItemRes(2L, 2L, item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage(), item2.getStore().getName(), item2.getStore().getCloseTime(), addressRes2);
 		List<ItemRes> itemResList = List.of(itemRes, itemRes2);
 		boolean hasNext = false;
 		ItemsRes itemsRes = new ItemsRes(itemResList, hasNext);
@@ -637,7 +631,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.items[0].information").value(itemRes.information()))
 			.andExpect(jsonPath("$.items[0].image").value(itemRes.image()))
 			.andExpect(jsonPath("$.items[0].storeName").value(itemRes.storeName()))
-			.andExpect(jsonPath("$.items[0].storeOpenTime").value(itemRes.storeOpenTime().toString()))
 			.andExpect(jsonPath("$.items[0].storeCloseTime").value(itemRes.storeCloseTime().toString()))
 			.andExpect(jsonPath("$.items[0].storeAddress.name").value(addressRes.name()))
 			.andExpect(jsonPath("$.items[0].storeAddress.xCoordinate").value(addressRes.xCoordinate()))
@@ -666,7 +659,6 @@ class ItemControllerTest {
 					fieldWithPath("items[0].information").type(STRING).description("안내 사항"),
 					fieldWithPath("items[0].image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("items[0].storeName").type(STRING).description("상호명"),
-					fieldWithPath("items[0].storeOpenTime").type(STRING).description("오픈 시간"),
 					fieldWithPath("items[0].storeCloseTime").type(STRING).description("마감 시간"),
 					fieldWithPath("items[0].storeAddress.name").type(STRING).description("업체 주소"),
 					fieldWithPath("items[0].storeAddress.xCoordinate").type(NUMBER).description("업체 주소 경도"),
@@ -699,8 +691,8 @@ class ItemControllerTest {
 
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 
-		ItemRes itemRes = new ItemRes(1L, storeId, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getOpenTime(), item.getStore().getCloseTime(), addressRes);
-		ItemRes itemRes3 = new ItemRes(2L, storeId, item3.getName(), item3.getStock(), item3.getDiscountPrice(), item3.getOriginalPrice(), item3.getDescription(), item3.getInformation(), item3.getImage(), item3.getStore().getName(), item3.getStore().getOpenTime(), item3.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes = new ItemRes(1L, storeId, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes3 = new ItemRes(2L, storeId, item3.getName(), item3.getStock(), item3.getDiscountPrice(), item3.getOriginalPrice(), item3.getDescription(), item3.getInformation(), item3.getImage(), item3.getStore().getName(), item3.getStore().getCloseTime(), addressRes);
 		List<ItemRes> itemResList = List.of(itemRes, itemRes3);
 		boolean hasNext = false;
 		ItemsRes itemsRes = new ItemsRes(itemResList, hasNext);
@@ -724,7 +716,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.items[0].information").value(itemRes.information()))
 			.andExpect(jsonPath("$.items[0].image").value(itemRes.image()))
 			.andExpect(jsonPath("$.items[0].storeName").value(itemRes.storeName()))
-			.andExpect(jsonPath("$.items[0].storeOpenTime").value(itemRes.storeOpenTime().toString()))
 			.andExpect(jsonPath("$.items[0].storeCloseTime").value(itemRes.storeCloseTime().toString()))
 			.andExpect(jsonPath("$.items[0].storeAddress.name").value(addressRes.name()))
 			.andExpect(jsonPath("$.items[0].storeAddress.xCoordinate").value(addressRes.xCoordinate()))
@@ -754,7 +745,6 @@ class ItemControllerTest {
 					fieldWithPath("items[0].information").type(STRING).description("안내 사항"),
 					fieldWithPath("items[0].image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("items[0].storeName").type(STRING).description("상호명"),
-					fieldWithPath("items[0].storeOpenTime").type(STRING).description("오픈 시간"),
 					fieldWithPath("items[0].storeCloseTime").type(STRING).description("마감 시간"),
 					fieldWithPath("items[0].storeAddress.name").type(STRING).description("업체 주소"),
 					fieldWithPath("items[0].storeAddress.xCoordinate").type(NUMBER).description("업체 주소 경도"),
@@ -775,7 +765,7 @@ class ItemControllerTest {
 
 		ItemReq itemReq = new ItemReq("치즈 떡볶이", 4, 9900, 14000, "치즈 떡볶이 입니다.", "통신사 할인 가능 합니다.");
 		ItemRes itemRes = new ItemRes(itemId, 1L, itemReq.itemName(), itemReq.stock(), itemReq.discountPrice(),
-			itemReq.originalPrice(), itemReq.description(), itemReq.information(), imageUrl, store.getName(), store.getOpenTime(), store.getCloseTime(), addressRes);
+			itemReq.originalPrice(), itemReq.description(), itemReq.information(), imageUrl, store.getName(), store.getCloseTime(), addressRes);
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -811,7 +801,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.information").value(itemRes.information()))
 			.andExpect(jsonPath("$.image").value(itemRes.image()))
 			.andExpect(jsonPath("$.storeName").value(itemRes.storeName()))
-			.andExpect(jsonPath("$.storeOpenTime").value(itemRes.storeOpenTime().toString()))
 			.andExpect(jsonPath("$.storeCloseTime").value(itemRes.storeCloseTime().toString()))
 			.andExpect(jsonPath("$.storeAddress.name").value(addressRes.name()))
 			.andExpect(jsonPath("$.storeAddress.xCoordinate").value(addressRes.xCoordinate()))
@@ -847,7 +836,6 @@ class ItemControllerTest {
 					fieldWithPath("information").type(STRING).description("안내 사항"),
 					fieldWithPath("image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("storeName").type(STRING).description("상호명"),
-					fieldWithPath("storeOpenTime").type(STRING).description("오픈 시간"),
 					fieldWithPath("storeCloseTime").type(STRING).description("마감 시간"),
 					fieldWithPath("storeAddress.name").type(STRING).description("업체 주소"),
 					fieldWithPath("storeAddress.xCoordinate").type(NUMBER).description("업체 주소 경도"),
@@ -879,7 +867,7 @@ class ItemControllerTest {
 		ItemReq itemReq = new ItemReq(item3.getName(), item3.getStock(), item3.getDiscountPrice(),
 			item3.getOriginalPrice(), item3.getDescription(), item3.getInformation());
 		ItemRes itemRes = new ItemRes(itemId, 1L, item3.getName(), item3.getStock(), item3.getDiscountPrice(),
-			item3.getOriginalPrice(), item3.getDescription(), item3.getInformation(), item3.getImage(), item3.getStore().getName(), item3.getStore().getOpenTime(), item3.getStore().getCloseTime(), addressRes);
+			item3.getOriginalPrice(), item3.getDescription(), item3.getInformation(), item3.getImage(), item3.getStore().getName(), item3.getStore().getCloseTime(), addressRes);
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",

--- a/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/item/presentation/ItemControllerTest.java
@@ -121,7 +121,6 @@ class ItemControllerTest {
 			.discountPrice(3000)
 			.originalPrice(4500)
 			.description("기본 떡볶이 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store)
 			.build();
@@ -150,7 +149,6 @@ class ItemControllerTest {
 			.discountPrice(4000)
 			.originalPrice(4500)
 			.description("김밥 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item2.png")
 			.store(store2)
 			.build();
@@ -163,8 +161,8 @@ class ItemControllerTest {
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 
 		ItemReq itemReq = new ItemReq(item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(),
-			item.getDescription(), item.getInformation());
-		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
+			item.getDescription());
+		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -189,7 +187,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.discountPrice").value(itemRes.discountPrice()))
 			.andExpect(jsonPath("$.originalPrice").value(itemRes.originalPrice()))
 			.andExpect(jsonPath("$.description").value(itemRes.description()))
-			.andExpect(jsonPath("$.information").value(itemRes.information()))
 			.andExpect(jsonPath("$.image").value(itemRes.image()))
 			.andExpect(jsonPath("$.storeName").value(itemRes.storeName()))
 			.andExpect(jsonPath("$.storeCloseTime").value(itemRes.storeCloseTime().toString()))
@@ -212,8 +209,7 @@ class ItemControllerTest {
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
-					fieldWithPath("description").type(STRING).description("상품 설명"),
-					fieldWithPath("information").type(STRING).description("상품 안내")
+					fieldWithPath("description").type(STRING).description("상품 설명")
 				),
 				responseFields(
 					fieldWithPath("itemId").type(NUMBER).description("상품 ID"),
@@ -223,7 +219,6 @@ class ItemControllerTest {
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
 					fieldWithPath("description").type(STRING).description("상세 설명"),
-					fieldWithPath("information").type(STRING).description("안내 사항"),
 					fieldWithPath("image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("storeName").type(STRING).description("상호명"),
 					fieldWithPath("storeCloseTime").type(STRING).description("마감 시간"),
@@ -244,15 +239,14 @@ class ItemControllerTest {
 			.discountPrice(4000)
 			.originalPrice(4500)
 			.description("기본 떡볶이 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.store(store)
 			.build();
 
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 
 		ItemReq itemReq = new ItemReq(item2.getName(), item2.getStock(), item2.getDiscountPrice(),
-			item2.getOriginalPrice(), item2.getDescription(), item2.getInformation());
-		ItemRes itemRes = new ItemRes(1L, 1L, item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage(), item2.getStore().getName(), item2.getStore().getCloseTime(), addressRes);
+			item2.getOriginalPrice(), item2.getDescription());
+		ItemRes itemRes = new ItemRes(1L, 1L, item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getImage(), item2.getStore().getName(), item2.getStore().getCloseTime(), addressRes);
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -296,8 +290,7 @@ class ItemControllerTest {
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
-					fieldWithPath("description").type(STRING).description("상품 설명"),
-					fieldWithPath("information").type(STRING).description("상품 안내")
+					fieldWithPath("description").type(STRING).description("상품 설명")
 				),
 				responseFields(
 					fieldWithPath("timestamp").type(STRING).description("예외 시간"),
@@ -315,7 +308,7 @@ class ItemControllerTest {
 	@Test
 	public void itemCreateFailureTest_invalidDiscountPrice() throws Exception {
 		//given
-		ItemReq itemReq = new ItemReq("떡볶이", 2, 4500, 4000, "기본 떡볶이 입니다.", "통신사 할인 불가능 합니다.");
+		ItemReq itemReq = new ItemReq("떡볶이", 2, 4500, 4000, "기본 떡볶이 입니다.");
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -354,8 +347,7 @@ class ItemControllerTest {
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
-					fieldWithPath("description").type(STRING).description("상품 설명"),
-					fieldWithPath("information").type(STRING).description("상품 안내")
+					fieldWithPath("description").type(STRING).description("상품 설명")
 				),
 				responseFields(
 					fieldWithPath("timestamp").type(STRING).description("예외 시간"),
@@ -370,7 +362,7 @@ class ItemControllerTest {
 	@Test
 	public void itemCreateFailureTest_duplicatedItemName() throws Exception {
 		//given
-		ItemReq itemReq = new ItemReq("떡볶이", 2, 4000, 4500, "기본 떡볶이 입니다.", "통신사 할인 불가능 합니다.");
+		ItemReq itemReq = new ItemReq("떡볶이", 2, 4000, 4500, "기본 떡볶이 입니다.");
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -409,8 +401,7 @@ class ItemControllerTest {
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
-					fieldWithPath("description").type(STRING).description("상품 설명"),
-					fieldWithPath("information").type(STRING).description("상품 안내")
+					fieldWithPath("description").type(STRING).description("상품 설명")
 				),
 				responseFields(
 					fieldWithPath("timestamp").type(STRING).description("예외 시간"),
@@ -429,7 +420,7 @@ class ItemControllerTest {
 
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 
-		ItemRes itemRes = new ItemRes(itemId, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getName(), item.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes = new ItemRes(itemId, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getImage(), item.getName(), item.getStore().getCloseTime(), addressRes);
 
 		when(itemService.findById(any())).thenReturn(itemRes);
 
@@ -445,7 +436,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.discountPrice").value(itemRes.discountPrice()))
 			.andExpect(jsonPath("$.originalPrice").value(itemRes.originalPrice()))
 			.andExpect(jsonPath("$.description").value(itemRes.description()))
-			.andExpect(jsonPath("$.information").value(itemRes.information()))
 			.andExpect(jsonPath("$.image").value(itemRes.image()))
 			.andExpect(jsonPath("$.storeName").value(itemRes.storeName()))
 			.andExpect(jsonPath("$.storeCloseTime").value(itemRes.storeCloseTime().toString()))
@@ -465,7 +455,6 @@ class ItemControllerTest {
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
 					fieldWithPath("description").type(STRING).description("상세 설명"),
-					fieldWithPath("information").type(STRING).description("안내 사항"),
 					fieldWithPath("image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("storeName").type(STRING).description("상호명"),
 					fieldWithPath("storeCloseTime").type(STRING).description("마감 시간"),
@@ -513,7 +502,6 @@ class ItemControllerTest {
 			.discountPrice(4000)
 			.originalPrice(4500)
 			.description("치즈 김밥 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item3.png")
 			.store(store)
 			.build();
@@ -524,8 +512,8 @@ class ItemControllerTest {
 
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 
-		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
-		ItemRes itemRes3 = new ItemRes(2L, 1L, item3.getName(), item3.getStock(), item3.getDiscountPrice(), item3.getOriginalPrice(), item3.getDescription(), item3.getInformation(), item3.getImage(), item3.getStore().getName(), item3.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes3 = new ItemRes(2L, 1L, item3.getName(), item3.getStock(), item3.getDiscountPrice(), item3.getOriginalPrice(), item3.getDescription(), item3.getImage(), item3.getStore().getName(), item3.getStore().getCloseTime(), addressRes);
 		List<ItemRes> itemResList = List.of(itemRes, itemRes3);
 		boolean hasNext = false;
 		ItemsRes itemsRes = new ItemsRes(itemResList, hasNext);
@@ -547,7 +535,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.items[0].discountPrice").value(itemRes.discountPrice()))
 			.andExpect(jsonPath("$.items[0].originalPrice").value(itemRes.originalPrice()))
 			.andExpect(jsonPath("$.items[0].description").value(itemRes.description()))
-			.andExpect(jsonPath("$.items[0].information").value(itemRes.information()))
 			.andExpect(jsonPath("$.items[0].image").value(itemRes.image()))
 			.andExpect(jsonPath("$.items[0].storeName").value(itemRes.storeName()))
 			.andExpect(jsonPath("$.items[0].storeCloseTime").value(itemRes.storeCloseTime().toString()))
@@ -576,7 +563,6 @@ class ItemControllerTest {
 					fieldWithPath("items[0].discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("items[0].originalPrice").type(NUMBER).description("원가"),
 					fieldWithPath("items[0].description").type(STRING).description("상세 설명"),
-					fieldWithPath("items[0].information").type(STRING).description("안내 사항"),
 					fieldWithPath("items[0].image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("items[0].storeName").type(STRING).description("상호명"),
 					fieldWithPath("items[0].storeCloseTime").type(STRING).description("마감 시간"),
@@ -603,8 +589,8 @@ class ItemControllerTest {
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 		AddressRes addressRes2 = new AddressRes(address2.getName(), address2.getXCoordinate(), address2.getYCoordinate());
 
-		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
-		ItemRes itemRes2 = new ItemRes(2L, 2L, item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getInformation(), item2.getImage(), item2.getStore().getName(), item2.getStore().getCloseTime(), addressRes2);
+		ItemRes itemRes = new ItemRes(1L, 1L, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes2 = new ItemRes(2L, 2L, item2.getName(), item2.getStock(), item2.getDiscountPrice(), item2.getOriginalPrice(), item2.getDescription(), item2.getImage(), item2.getStore().getName(), item2.getStore().getCloseTime(), addressRes2);
 		List<ItemRes> itemResList = List.of(itemRes, itemRes2);
 		boolean hasNext = false;
 		ItemsRes itemsRes = new ItemsRes(itemResList, hasNext);
@@ -628,7 +614,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.items[0].discountPrice").value(itemRes.discountPrice()))
 			.andExpect(jsonPath("$.items[0].originalPrice").value(itemRes.originalPrice()))
 			.andExpect(jsonPath("$.items[0].description").value(itemRes.description()))
-			.andExpect(jsonPath("$.items[0].information").value(itemRes.information()))
 			.andExpect(jsonPath("$.items[0].image").value(itemRes.image()))
 			.andExpect(jsonPath("$.items[0].storeName").value(itemRes.storeName()))
 			.andExpect(jsonPath("$.items[0].storeCloseTime").value(itemRes.storeCloseTime().toString()))
@@ -656,7 +641,6 @@ class ItemControllerTest {
 					fieldWithPath("items[0].discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("items[0].originalPrice").type(NUMBER).description("원가"),
 					fieldWithPath("items[0].description").type(STRING).description("상세 설명"),
-					fieldWithPath("items[0].information").type(STRING).description("안내 사항"),
 					fieldWithPath("items[0].image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("items[0].storeName").type(STRING).description("상호명"),
 					fieldWithPath("items[0].storeCloseTime").type(STRING).description("마감 시간"),
@@ -680,7 +664,6 @@ class ItemControllerTest {
 			.discountPrice(4000)
 			.originalPrice(4500)
 			.description("치즈 김밥 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item3.png")
 			.store(store)
 			.build();
@@ -691,8 +674,8 @@ class ItemControllerTest {
 
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 
-		ItemRes itemRes = new ItemRes(1L, storeId, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getInformation(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
-		ItemRes itemRes3 = new ItemRes(2L, storeId, item3.getName(), item3.getStock(), item3.getDiscountPrice(), item3.getOriginalPrice(), item3.getDescription(), item3.getInformation(), item3.getImage(), item3.getStore().getName(), item3.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes = new ItemRes(1L, storeId, item.getName(), item.getStock(), item.getDiscountPrice(), item.getOriginalPrice(), item.getDescription(), item.getImage(), item.getStore().getName(), item.getStore().getCloseTime(), addressRes);
+		ItemRes itemRes3 = new ItemRes(2L, storeId, item3.getName(), item3.getStock(), item3.getDiscountPrice(), item3.getOriginalPrice(), item3.getDescription(), item3.getImage(), item3.getStore().getName(), item3.getStore().getCloseTime(), addressRes);
 		List<ItemRes> itemResList = List.of(itemRes, itemRes3);
 		boolean hasNext = false;
 		ItemsRes itemsRes = new ItemsRes(itemResList, hasNext);
@@ -713,7 +696,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.items[0].discountPrice").value(itemRes.discountPrice()))
 			.andExpect(jsonPath("$.items[0].originalPrice").value(itemRes.originalPrice()))
 			.andExpect(jsonPath("$.items[0].description").value(itemRes.description()))
-			.andExpect(jsonPath("$.items[0].information").value(itemRes.information()))
 			.andExpect(jsonPath("$.items[0].image").value(itemRes.image()))
 			.andExpect(jsonPath("$.items[0].storeName").value(itemRes.storeName()))
 			.andExpect(jsonPath("$.items[0].storeCloseTime").value(itemRes.storeCloseTime().toString()))
@@ -742,7 +724,6 @@ class ItemControllerTest {
 					fieldWithPath("items[0].discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("items[0].originalPrice").type(NUMBER).description("원가"),
 					fieldWithPath("items[0].description").type(STRING).description("상세 설명"),
-					fieldWithPath("items[0].information").type(STRING).description("안내 사항"),
 					fieldWithPath("items[0].image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("items[0].storeName").type(STRING).description("상호명"),
 					fieldWithPath("items[0].storeCloseTime").type(STRING).description("마감 시간"),
@@ -763,9 +744,9 @@ class ItemControllerTest {
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 		String imageUrl = "http://image-url.com/image.jpg";
 
-		ItemReq itemReq = new ItemReq("치즈 떡볶이", 4, 9900, 14000, "치즈 떡볶이 입니다.", "통신사 할인 가능 합니다.");
+		ItemReq itemReq = new ItemReq("치즈 떡볶이", 4, 9900, 14000, "치즈 떡볶이 입니다.");
 		ItemRes itemRes = new ItemRes(itemId, 1L, itemReq.itemName(), itemReq.stock(), itemReq.discountPrice(),
-			itemReq.originalPrice(), itemReq.description(), itemReq.information(), imageUrl, store.getName(), store.getCloseTime(), addressRes);
+			itemReq.originalPrice(), itemReq.description(), imageUrl, store.getName(), store.getCloseTime(), addressRes);
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -798,7 +779,6 @@ class ItemControllerTest {
 			.andExpect(jsonPath("$.discountPrice").value(itemRes.discountPrice()))
 			.andExpect(jsonPath("$.originalPrice").value(itemRes.originalPrice()))
 			.andExpect(jsonPath("$.description").value(itemRes.description()))
-			.andExpect(jsonPath("$.information").value(itemRes.information()))
 			.andExpect(jsonPath("$.image").value(itemRes.image()))
 			.andExpect(jsonPath("$.storeName").value(itemRes.storeName()))
 			.andExpect(jsonPath("$.storeCloseTime").value(itemRes.storeCloseTime().toString()))
@@ -822,8 +802,7 @@ class ItemControllerTest {
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
-					fieldWithPath("description").type(STRING).description("상품 설명"),
-					fieldWithPath("information").type(STRING).description("상품 안내")
+					fieldWithPath("description").type(STRING).description("상품 설명")
 				),
 				responseFields(
 					fieldWithPath("itemId").type(NUMBER).description("상품 ID"),
@@ -833,7 +812,6 @@ class ItemControllerTest {
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
 					fieldWithPath("description").type(STRING).description("상세 설명"),
-					fieldWithPath("information").type(STRING).description("안내 사항"),
 					fieldWithPath("image").type(STRING).description("상품 이미지 경로"),
 					fieldWithPath("storeName").type(STRING).description("상호명"),
 					fieldWithPath("storeCloseTime").type(STRING).description("마감 시간"),
@@ -857,7 +835,6 @@ class ItemControllerTest {
 			.discountPrice(9900)
 			.originalPrice(14500)
 			.description("치즈 떡볶이 입니다.")
-			.information("통신사 할인 가능 합니다.")
 			.image(imageUrl)
 			.store(store)
 			.build();
@@ -865,9 +842,9 @@ class ItemControllerTest {
 		AddressRes addressRes = new AddressRes(address.getName(), address.getXCoordinate(), address.getYCoordinate());
 
 		ItemReq itemReq = new ItemReq(item3.getName(), item3.getStock(), item3.getDiscountPrice(),
-			item3.getOriginalPrice(), item3.getDescription(), item3.getInformation());
+			item3.getOriginalPrice(), item3.getDescription());
 		ItemRes itemRes = new ItemRes(itemId, 1L, item3.getName(), item3.getStock(), item3.getDiscountPrice(),
-			item3.getOriginalPrice(), item3.getDescription(), item3.getInformation(), item3.getImage(), item3.getStore().getName(), item3.getStore().getCloseTime(), addressRes);
+			item3.getOriginalPrice(), item3.getDescription(), item3.getImage(), item3.getStore().getName(), item3.getStore().getCloseTime(), addressRes);
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -919,8 +896,7 @@ class ItemControllerTest {
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
-					fieldWithPath("description").type(STRING).description("상품 설명"),
-					fieldWithPath("information").type(STRING).description("상품 안내")
+					fieldWithPath("description").type(STRING).description("상품 설명")
 				),
 				responseFields(
 					fieldWithPath("timestamp").type(STRING).description("예외 시간"),
@@ -938,7 +914,7 @@ class ItemControllerTest {
 	@Test
 	public void itemUpdateFailureTest_invalidDiscountPrice() throws Exception {
 		//given
-		ItemReq itemReq = new ItemReq("치즈 떡볶이", 4, 10000, 5000, "치즈 떡볶이 입니다.", "통신사 할인 가능 합니다.");
+		ItemReq itemReq = new ItemReq("치즈 떡볶이", 4, 10000, 5000, "치즈 떡볶이 입니다.");
 
 		Long itemId = 1L;
 
@@ -988,8 +964,7 @@ class ItemControllerTest {
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
-					fieldWithPath("description").type(STRING).description("상품 설명"),
-					fieldWithPath("information").type(STRING).description("상품 안내")
+					fieldWithPath("description").type(STRING).description("상품 설명")
 				),
 				responseFields(
 					fieldWithPath("timestamp").type(STRING).description("예외 시간"),
@@ -1013,13 +988,12 @@ class ItemControllerTest {
 			.discountPrice(9900)
 			.originalPrice(14500)
 			.description("치즈 떡볶이 입니다.")
-			.information("통신사 할인 가능 합니다.")
 			.image(imageUrl)
 			.store(store)
 			.build();
 
 		ItemReq itemReq = new ItemReq(item3.getName(), item3.getStock(), item3.getDiscountPrice(),
-			item3.getOriginalPrice(), item3.getDescription(), item3.getInformation());
+			item3.getOriginalPrice(), item3.getDescription());
 
 		MockMultipartFile file = new MockMultipartFile("image", "test.jpg", "image/jpeg", "file".getBytes());
 		MockMultipartFile request = new MockMultipartFile("itemReq", "itemReq",
@@ -1067,8 +1041,7 @@ class ItemControllerTest {
 					fieldWithPath("stock").type(NUMBER).description("재고 수"),
 					fieldWithPath("discountPrice").type(NUMBER).description("할인가"),
 					fieldWithPath("originalPrice").type(NUMBER).description("원가"),
-					fieldWithPath("description").type(STRING).description("상품 설명"),
-					fieldWithPath("information").type(STRING).description("상품 안내")
+					fieldWithPath("description").type(STRING).description("상품 설명")
 				),
 				responseFields(
 					fieldWithPath("timestamp").type(STRING).description("예외 시간"),

--- a/src/test/java/com/palpal/dealightbe/domain/order/application/OrderServiceIntegrationTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/order/application/OrderServiceIntegrationTest.java
@@ -239,7 +239,6 @@ public class OrderServiceIntegrationTest {
 			.originalPrice(4500)
 			.discountPrice(4000)
 			.description("기본 떡볶이 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.store(store)
 			.build();
 

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -158,7 +158,6 @@ class StoreServiceTest {
 			.discountPrice(3000)
 			.originalPrice(4500)
 			.description("기본 떡볶이 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store)
 			.build();
@@ -169,7 +168,6 @@ class StoreServiceTest {
 			.discountPrice(4000)
 			.originalPrice(4500)
 			.description("기본 떡볶이 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store2)
 			.build();
@@ -180,7 +178,6 @@ class StoreServiceTest {
 			.discountPrice(100)
 			.originalPrice(4500)
 			.description("기본 순대 입니다.")
-			.information("통신사 할인 불가능 합니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store3)
 			.build();


### PR DESCRIPTION
## 💡 관련 이슈

- close: #219 

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약
- Item 필드와 Item Response 내용을 수정했습니다.


<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명
- 초반에 구성했던 기능에 storeOpenTime이 필요하지 않아 삭제했습니다.
- 프론트의 화면 디자인 변경으로 Item의 information 필드가 더이상 필요하지 않게 되어 삭제했습니다.


## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->