### PR TITLE
업체 마이페이지 API 수정 및 업체 상세 페이지(고객 사용) API 추가

### DIFF
--- a/src/docs/asciidoc/Store.adoc
+++ b/src/docs/asciidoc/Store.adoc
@@ -42,13 +42,12 @@ include::{snippets}/store/store-register-fail-not-found-member/http-response.ado
 
 include::{snippets}/store/store-register-fail-not-found-member/response-fields.adoc[]
 
-=== 업체 마이 페이지 조회
+=== 업체 마이 페이지 조회 - 업체 사용
 
-==== GET - /api/stores/profiles/{storeId}
+==== GET - /api/stores/profiles
 
 .Request
 include::{snippets}/store/store-get-info/http-request.adoc[]
-include::{snippets}/store/store-get-info/path-parameters.adoc[]
 
 .Response
 include::{snippets}/store/store-get-info/http-response.adoc[]
@@ -65,6 +64,18 @@ include::{snippets}/store/store-update-info/path-parameters.adoc[]
 .Response
 include::{snippets}/store/store-update-info/http-response.adoc[]
 include::{snippets}/store/store-update-info/response-fields.adoc[]
+
+=== 업체 상세 페이지 조회 - 고객 사용
+
+==== GET - /api/stores/profiles/{storeId}
+
+.Request
+include::{snippets}/store/store-get-details/http-request.adoc[]
+include::{snippets}/store/store-get-details/path-parameters.adoc[]
+
+.Response
+include::{snippets}/store/store-get-info/http-response.adoc[]
+include::{snippets}/store/store-get-info/response-fields.adoc[]
 
 === 업체 영업 상태 조회
 

--- a/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
@@ -46,11 +46,18 @@ public class StoreController {
 	}
 
 	@ProviderId
-	@GetMapping("/profiles/{storeId}")
-	public ResponseEntity<StoreInfoRes> getInfo(Long providerId, @PathVariable Long storeId) {
-		StoreInfoRes infoRes = storeService.getInfo(providerId, storeId);
+	@GetMapping("/profiles")
+	public ResponseEntity<StoreInfoRes> getInfo(Long providerId) {
+		StoreInfoRes infoRes = storeService.getInfo(providerId);
 
 		return ResponseEntity.ok(infoRes);
+	}
+
+	@GetMapping("/profiles/{storeId}")
+	public ResponseEntity<StoreInfoRes> getDetails(@PathVariable Long storeId) {
+		StoreInfoRes detailsRes = storeService.getDetails(storeId);
+
+		return ResponseEntity.ok(detailsRes);
 	}
 
 	@ProviderId

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -290,11 +290,11 @@ class StoreServiceTest {
 		//given
 		when(memberRepository.findMemberByProviderId(member.getProviderId()))
 			.thenReturn(Optional.of(member));
-		when(storeRepository.findById(store.getId()))
+		when(storeRepository.findByMemberProviderId(member.getProviderId()))
 			.thenReturn(Optional.of(store));
 
 		//when
-		StoreInfoRes infoRes = storeService.getInfo(member.getProviderId(), store.getId());
+		StoreInfoRes infoRes = storeService.getInfo(member.getProviderId());
 
 		//then
 		Set<String> dayOffs = store.getDayOffs().stream()
@@ -322,12 +322,12 @@ class StoreServiceTest {
 
 		when(memberRepository.findMemberByProviderId(invalidMember.getProviderId()))
 			.thenReturn(Optional.of(invalidMember));
-		when(storeRepository.findById(store.getId()))
+		when(storeRepository.findByMemberProviderId(invalidMember.getProviderId()))
 			.thenReturn(Optional.of(store));
 
 		//when -> then
 		assertThrows(BusinessException.class, () -> {
-			storeService.getInfo(invalidMember.getProviderId(), store.getId());
+			storeService.getInfo(invalidMember.getProviderId());
 		});
 	}
 


### PR DESCRIPTION
## 💡 관련 이슈

- close: #226 

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

- 업체가 사용하는 마이페이지 API에는 엔드포인트의 Path Parameter인 storeId를 제거하고, 토큰으로만 확인하게 변경하였습니다.
- 고객이 사용하는 업체 상세페이지는 모든 유저가 사용할 수 있게 헤더의 토큰을 제거하고, Path Parameter에 조회하려는 storeId를 받게 하도록 추가하였습니다.

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명

주요 기능/로직 및 작업 내용에 관해 설명해주세요.

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->