### PR TITLE
ItemRepository 조회 쿼리 페치 조인 적용

### DIFF
--- a/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemRepository.java
@@ -3,6 +3,8 @@ package com.palpal.dealightbe.domain.item.domain;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
 
@@ -11,4 +13,7 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
 	Optional<Item> findByNameAndStoreId(String name, Long storeId);
 
 	void deleteAllByStoreId(Long storeId);
+
+	@Query("SELECT i FROM Item i JOIN FETCH i.store s JOIN FETCH s.address WHERE i.id = :id")
+	Optional<Item> findById(@Param("id") Long id);
 }

--- a/src/test/java/com/palpal/dealightbe/domain/order/application/OrderServiceIntegrationTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/order/application/OrderServiceIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.palpal.dealightbe.domain.address.domain.Address;
 import com.palpal.dealightbe.domain.item.domain.Item;
 import com.palpal.dealightbe.domain.item.domain.ItemRepository;
 import com.palpal.dealightbe.domain.member.domain.Member;
@@ -248,8 +249,17 @@ public class OrderServiceIntegrationTest {
 		}
 	}
 
+	private Address createAddress() {
+
+		return Address.builder()
+			.xCoordinate(127.0324773)
+			.yCoordinate(37.5893876)
+			.build();
+	}
+
 	private Store createStore() {
 		Member storeOwner = createMember();
+		Address address = createAddress();
 
 		Store store = Store.builder()
 			.name("GS25")
@@ -258,6 +268,7 @@ public class OrderServiceIntegrationTest {
 			.openTime(LocalTime.of(9, 0))
 			.closeTime(LocalTime.of(18, 0))
 			.dayOff(Set.of(DayOff.SAT, DayOff.SUN))
+			.address(address)
 			.build();
 
 		store.updateMember(storeOwner);


### PR DESCRIPTION
## 💡 관련 이슈

- close: #263 

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약
- ItemRepository 조회 쿼리 페치 조인 적용

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명
- ItemRepository 의 findById 쿼리 실행 시 Item, Store, Address를 조회하는 쿼리 3개가 호출 되는 것을 페치 조인으로 한 번에 조회하도록 개선했습니다.

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->