### PR TITLE
업체 검색 QueryDsl -> ElasticSearch 도입

### DIFF
--- a/src/docs/asciidoc/Search.adoc
+++ b/src/docs/asciidoc/Search.adoc
@@ -1,0 +1,19 @@
+= REST Docs 검색 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+[[Search-API]]
+== Search API
+=== 검색어로 업체 검색
+
+==== GET - /api/search?x-coordinate={xcoordinate}&y-coordinate={yCoordinate}&keyword={keywords}sortBy={sortBy}&size={size}&page={page}
+
+.Request
+include::{snippets}/search/search-by-option/http-request.adoc[]
+include::{snippets}/search/search-by-option/request-parameters.adoc[]
+.Response
+include::{snippets}/search/search-by-option/http-response.adoc[]
+include::{snippets}/search/search-by-option/response-fields.adoc[]

--- a/src/docs/asciidoc/Store.adoc
+++ b/src/docs/asciidoc/Store.adoc
@@ -5,7 +5,7 @@
 :toc: left
 :toclevels: 2
 
-[[User-API]]
+[[Store-API]]
 == Store API
 
 === 업체 등록 - 성공

--- a/src/main/java/com/palpal/dealightbe/domain/address/domain/Address.java
+++ b/src/main/java/com/palpal/dealightbe/domain/address/domain/Address.java
@@ -1,6 +1,5 @@
 package com.palpal.dealightbe.domain.address.domain;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -9,10 +8,8 @@ import javax.persistence.Table;
 
 import com.palpal.dealightbe.global.BaseEntity;
 
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @Entity

--- a/src/main/java/com/palpal/dealightbe/domain/item/application/ItemService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/application/ItemService.java
@@ -16,8 +16,13 @@ import com.palpal.dealightbe.domain.item.application.dto.response.ItemRes;
 import com.palpal.dealightbe.domain.item.application.dto.response.ItemsRes;
 import com.palpal.dealightbe.domain.item.domain.Item;
 import com.palpal.dealightbe.domain.item.domain.ItemRepository;
+import com.palpal.dealightbe.domain.item.domain.UpdatedItem;
+import com.palpal.dealightbe.domain.item.domain.UpdatedItemRepository;
 import com.palpal.dealightbe.domain.store.domain.Store;
 import com.palpal.dealightbe.domain.store.domain.StoreRepository;
+import com.palpal.dealightbe.domain.store.domain.UpdatedStore;
+import com.palpal.dealightbe.domain.store.domain.UpdatedStoreRepository;
+import com.palpal.dealightbe.global.error.ErrorCode;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
 
@@ -33,7 +38,9 @@ public class ItemService {
 	public static final String DEFAULT_ITEM_IMAGE_PATH = "https://team-08-bucket.s3.ap-northeast-2.amazonaws.com/image/default-item-image.png";
 
 	private final ItemRepository itemRepository;
+	private final UpdatedItemRepository updatedItemRepository;
 	private final StoreRepository storeRepository;
+	private final UpdatedStoreRepository updatedStoreRepository;
 	private final ImageService imageService;
 
 	public ItemRes create(ItemReq itemReq, Long providerId, ImageUploadReq imageUploadReq) {
@@ -45,6 +52,18 @@ public class ItemService {
 		Item item = ItemReq.toItem(itemReq, store, imageUrl);
 		item.updateStore(store);
 		Item savedItem = itemRepository.save(item);
+		store.addItem(item);
+
+		UpdatedStore updatedStore = updatedStoreRepository.findById(store.getId())
+			.orElseThrow(() -> {
+				log.warn("GET:READ:NOT_FOUND_UPDATED_STORE_BY_STORE_ID : {}", store.getId());
+				return new BusinessException(ErrorCode.NOT_FOUND_UPDATED_STORE);
+			});
+
+		UpdatedItem updatedItem = UpdatedItem.from(item);
+		updatedItem.updateStore(updatedStore);
+		updatedItemRepository.save(updatedItem);
+		updatedStore.addItem(updatedItem);
 
 		return ItemRes.from(savedItem);
 	}

--- a/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemDocument.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemDocument.java
@@ -9,14 +9,11 @@ import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(indexName = "item")
 @Mapping(mappingPath = "elastic/item-mapping.json")
@@ -30,11 +27,29 @@ public class ItemDocument {
 
 	private String storeId;
 
+	private int discountPrice;
+
+	private int originalPrice;
+
+	private double discountRate;
+
+	@Builder
+	public ItemDocument(String id, String name, String storeId, int discountPrice, int originalPrice) {
+		this.id = id;
+		this.name = name;
+		this.storeId = storeId;
+		this.discountPrice = discountPrice;
+		this.originalPrice = originalPrice;
+		this.discountRate = calculateDiscountRate(originalPrice, discountPrice);
+	}
+
 	public static ItemDocument from(UpdatedItem item) {
 		return ItemDocument.builder()
 			.id(String.valueOf(item.getId()))
 			.name(item.getName())
 			.storeId(String.valueOf(item.getStore().getId()))
+			.discountPrice(item.getDiscountPrice())
+			.originalPrice(item.getOriginalPrice())
 			.build();
 	}
 
@@ -46,5 +61,13 @@ public class ItemDocument {
 		return items.stream()
 			.map(ItemDocument::from)
 			.toList();
+	}
+
+	private double calculateDiscountRate(int originalPrice, int discountPrice) {
+		if (originalPrice != 0) {
+			return discountRate = (originalPrice - discountPrice) / (double) originalPrice * 100.0;
+		} else {
+			return discountRate = 0.0;
+		}
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemDocument.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemDocument.java
@@ -1,7 +1,6 @@
 package com.palpal.dealightbe.domain.item.domain;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.persistence.Id;
 
@@ -29,23 +28,23 @@ public class ItemDocument {
 
 	private String name;
 
-	private Long storeId;
+	private String storeId;
 
-	public static ItemDocument from(Item item) {
+	public static ItemDocument from(UpdatedItem item) {
 		return ItemDocument.builder()
 			.id(String.valueOf(item.getId()))
 			.name(item.getName())
-			.storeId(item.getStore().getId())
+			.storeId(String.valueOf(item.getStore().getId()))
 			.build();
 	}
 
-	public static List<ItemDocument> convertToItemDocuments(List<Item> items) {
+	public static List<ItemDocument> convertToItemDocuments(List<UpdatedItem> items) {
 		if (items == null) {
 			return null;
 		}
+
 		return items.stream()
 			.map(ItemDocument::from)
-			.collect(Collectors.toList());
+			.toList();
 	}
-
 }

--- a/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemDocument.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemDocument.java
@@ -1,5 +1,8 @@
 package com.palpal.dealightbe.domain.item.domain;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.persistence.Id;
 
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -22,7 +25,7 @@ import lombok.NoArgsConstructor;
 public class ItemDocument {
 
 	@Id
-	private Long id;
+	private String id;
 
 	private String name;
 
@@ -30,9 +33,19 @@ public class ItemDocument {
 
 	public static ItemDocument from(Item item) {
 		return ItemDocument.builder()
-			.id(item.getId())
+			.id(String.valueOf(item.getId()))
 			.name(item.getName())
 			.storeId(item.getStore().getId())
 			.build();
 	}
+
+	public static List<ItemDocument> convertToItemDocuments(List<Item> items) {
+		if (items == null) {
+			return null;
+		}
+		return items.stream()
+			.map(ItemDocument::from)
+			.collect(Collectors.toList());
+	}
+
 }

--- a/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemDocumentRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/domain/ItemDocumentRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ItemSearchRepository extends ElasticsearchRepository<ItemDocument, Long> {
+public interface ItemDocumentRepository extends ElasticsearchRepository<ItemDocument, Long> {
 }

--- a/src/main/java/com/palpal/dealightbe/domain/item/domain/UpdatedItem.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/domain/UpdatedItem.java
@@ -1,0 +1,77 @@
+package com.palpal.dealightbe.domain.item.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import com.palpal.dealightbe.domain.store.domain.DocumentStatus;
+import com.palpal.dealightbe.domain.store.domain.UpdatedStore;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Entity
+@Table(name = "updated_items")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdatedItem {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+	private int stock;
+	private int discountPrice;
+
+	private int originalPrice;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private UpdatedStore store;
+
+	@Enumerated(EnumType.STRING)
+	private DocumentStatus documentStatus = DocumentStatus.READY;
+
+	@Builder
+	public UpdatedItem(Long id, String name, int stock, int discountPrice, int originalPrice, UpdatedStore store) {
+		this.id = id;
+		this.name = name;
+		this.stock = stock;
+		this.discountPrice = discountPrice;
+		this.originalPrice = originalPrice;
+		this.store = store;
+	}
+
+	public static UpdatedItem from(Item item) {
+		return UpdatedItem.builder()
+			.name(item.getName())
+			.stock(item.getStock())
+			.discountPrice(item.getDiscountPrice())
+			.originalPrice(item.getOriginalPrice())
+			.build();
+	}
+
+	public void updateDocumentStatus(DocumentStatus status) {
+		this.documentStatus = status;
+	}
+
+	public void updateStore(UpdatedStore updatedStore) {
+		this.store = updatedStore;
+	}
+
+	public void markAsDone() {
+		this.documentStatus = DocumentStatus.DONE;
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/item/domain/UpdatedItemRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/domain/UpdatedItemRepository.java
@@ -1,6 +1,12 @@
 package com.palpal.dealightbe.domain.item.domain;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UpdatedItemRepository extends JpaRepository<UpdatedItem, Long> {
+
+	@Query("SELECT ui FROM UpdatedItem ui WHERE ui.documentStatus != 'DONE'")
+	List<UpdatedItem> findAllByDocumentStatusIsReady();
 }

--- a/src/main/java/com/palpal/dealightbe/domain/item/domain/UpdatedItemRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/domain/UpdatedItemRepository.java
@@ -1,0 +1,6 @@
+package com.palpal.dealightbe.domain.item.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UpdatedItemRepository extends JpaRepository<UpdatedItem, Long> {
+}

--- a/src/main/java/com/palpal/dealightbe/domain/item/infrastructure/ItemSearchRepositoryImpl.java
+++ b/src/main/java/com/palpal/dealightbe/domain/item/infrastructure/ItemSearchRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.palpal.dealightbe.domain.item.infrastructure;
+
+
+import java.util.List;
+
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.stereotype.Repository;
+
+import com.palpal.dealightbe.domain.item.domain.ItemDocument;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ItemSearchRepositoryImpl {
+
+	private final ElasticsearchOperations operations;
+
+	public void bulkInsertOrUpdate(List<ItemDocument> itemDocuments) {
+		List<UpdateQuery> updateQueries = itemDocuments.stream().map(itemDocument ->
+			UpdateQuery.builder(String.valueOf(itemDocument.getId()))
+				.withDocument(operations.getElasticsearchConverter().mapObject(itemDocument))
+				.withDocAsUpsert(true)
+				.build()).toList();
+
+		operations.bulkUpdate(updateQueries, operations.getIndexCoordinatesFor(ItemDocument.class));
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/search/application/SearchService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/search/application/SearchService.java
@@ -1,0 +1,112 @@
+package com.palpal.dealightbe.domain.search.application;
+
+import static com.palpal.dealightbe.domain.item.domain.ItemDocument.convertToItemDocuments;
+import static com.palpal.dealightbe.domain.store.domain.StoreDocument.convertToStoreDocuments;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.palpal.dealightbe.domain.item.domain.UpdatedItem;
+import com.palpal.dealightbe.domain.item.domain.UpdatedItemRepository;
+import com.palpal.dealightbe.domain.item.infrastructure.ItemSearchRepositoryImpl;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoresInfoSliceRes;
+import com.palpal.dealightbe.domain.store.domain.DocumentStatus;
+import com.palpal.dealightbe.domain.store.domain.StoreDocument;
+import com.palpal.dealightbe.domain.store.domain.StoreStatus;
+import com.palpal.dealightbe.domain.store.domain.UpdatedStore;
+import com.palpal.dealightbe.domain.store.domain.UpdatedStoreRepository;
+import com.palpal.dealightbe.domain.store.infrastructure.StoreSearchRepositoryImpl;
+import com.palpal.dealightbe.global.error.ErrorCode;
+import com.palpal.dealightbe.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SearchService {
+
+	private final UpdatedStoreRepository updatedStoreRepository;
+	private final StoreSearchRepositoryImpl storeSearchRepositoryImpl;
+	private final UpdatedItemRepository updatedItemRepository;
+	private final ItemSearchRepositoryImpl itemSearchRepositoryImpl;
+
+	@Transactional(readOnly = true)
+	public StoresInfoSliceRes searchToES(double xCoordinate, double yCoordinate, String keyword, Pageable pageable) {
+		Slice<StoreDocument> storeDocuments = storeSearchRepositoryImpl.searchStores(xCoordinate, yCoordinate, keyword, pageable);
+
+		return StoresInfoSliceRes.fromDocuments(storeDocuments);
+	}
+
+	public void uploadToES() {
+		List<UpdatedStore> updatedStoreList = updatedStoreRepository.findAll();
+		validateAndBulkStores(updatedStoreList, storeSearchRepositoryImpl);
+
+		List<UpdatedItem> updatedItemList = updatedItemRepository.findAll();
+		validateAndBulkItems(updatedItemList, itemSearchRepositoryImpl);
+
+		markDocumentsAsDone(updatedItemList, updatedStoreList);
+	}
+
+	public void updateStatusToES() {
+		List<UpdatedStore> updatedStoreList = updatedStoreRepository.findAll();
+		updateStoreDocuments(updatedStoreList, storeSearchRepositoryImpl);
+	}
+
+	private void validateAndBulkStores(List<UpdatedStore> updatedStoreList, StoreSearchRepositoryImpl storeSearchRepository) {
+		if (updatedStoreList.isEmpty()) {
+			throw new BusinessException(ErrorCode.UPDATABLE_STORE_NOT_EXIST);
+		}
+
+		updatedStoreList.forEach(updatedStore -> {
+			if (updatedStore.getDocumentStatus() != DocumentStatus.DONE) {
+				storeSearchRepository.bulkInsertOrUpdate(convertToStoreDocuments(updatedStoreList));
+			}
+		});
+	}
+
+	private void validateAndBulkItems(List<UpdatedItem> updatedItemList, ItemSearchRepositoryImpl itemSearchRepository) {
+		updatedItemList.forEach(updatedItem -> {
+			if (updatedItem.getDocumentStatus() != DocumentStatus.DONE) {
+				itemSearchRepository.bulkInsertOrUpdate(convertToItemDocuments(updatedItemList));
+			}
+		});
+	}
+
+	private void markDocumentsAsDone(List<UpdatedItem> updatedItemList, List<UpdatedStore> updatedStoreList) {
+		updatedItemList.forEach(UpdatedItem::markAsDone);
+		updatedStoreList.forEach(UpdatedStore::markAsDone);
+	}
+
+	private void updateStoreDocuments(List<UpdatedStore> updatedStoreList, StoreSearchRepositoryImpl storeSearchRepositoryImpl) {
+		updatedStoreList.forEach(updatedStore -> {
+			if (updatedStore.getDocumentStatus() == DocumentStatus.DONE) {
+				StoreDocument existingStoreDocument = storeSearchRepositoryImpl.findById(String.valueOf(updatedStore.getId()));
+				if (existingStoreDocument != null) {
+					updateStoreStatusIfNeeded(updatedStore, existingStoreDocument, storeSearchRepositoryImpl);
+					updateStoreItemsIfNeeded(updatedStore, storeSearchRepositoryImpl);
+				}
+			}
+		});
+	}
+
+	private void updateStoreStatusIfNeeded(UpdatedStore updatedStore, StoreDocument existingStoreDocument, StoreSearchRepositoryImpl storeSearchRepository) {
+		StoreStatus currentStatus = updatedStore.getStoreStatus();
+		StoreStatus existingStatus = existingStoreDocument.getStoreStatus();
+
+		if (currentStatus != existingStatus) {
+			storeSearchRepository.updateStoreStatus(String.valueOf(updatedStore.getId()), currentStatus);
+		}
+	}
+
+	private void updateStoreItemsIfNeeded(UpdatedStore updatedStore, StoreSearchRepositoryImpl storeSearchRepository) {
+		if (updatedStore.getItems() != null && !updatedStore.getItems().isEmpty()) {
+			storeSearchRepository.updateStoreItems(String.valueOf(updatedStore.getId()), convertToItemDocuments(updatedStore.getItems()));
+		}
+	}
+
+}

--- a/src/main/java/com/palpal/dealightbe/domain/search/application/SearchService.java
+++ b/src/main/java/com/palpal/dealightbe/domain/search/application/SearchService.java
@@ -36,8 +36,8 @@ public class SearchService {
 	private final ItemSearchRepositoryImpl itemSearchRepositoryImpl;
 
 	@Transactional(readOnly = true)
-	public StoresInfoSliceRes searchToES(double xCoordinate, double yCoordinate, String keyword, Pageable pageable) {
-		Slice<StoreDocument> storeDocuments = storeSearchRepositoryImpl.searchStores(xCoordinate, yCoordinate, keyword, pageable);
+	public StoresInfoSliceRes searchToES(double xCoordinate, double yCoordinate, String keyword, String sortBy, Pageable pageable) {
+		Slice<StoreDocument> storeDocuments = storeSearchRepositoryImpl.searchStores(xCoordinate, yCoordinate, keyword, sortBy, pageable);
 
 		return StoresInfoSliceRes.fromDocuments(storeDocuments);
 	}

--- a/src/main/java/com/palpal/dealightbe/domain/search/infrastructure/SearchESScheduler.java
+++ b/src/main/java/com/palpal/dealightbe/domain/search/infrastructure/SearchESScheduler.java
@@ -1,0 +1,29 @@
+package com.palpal.dealightbe.domain.search.infrastructure;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.palpal.dealightbe.domain.search.application.SearchService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SearchESScheduler {
+
+	private final SearchService searchService;
+
+	// 업로드 메서드를 1시간마다 실행
+	@Scheduled(cron = "0 0 0/1 * * *")
+	public void uploadToES() {
+		searchService.uploadToES();
+	}
+
+	// 업데이트 메서드를 30분마다 실행
+	@Scheduled(cron = "0 0/30 * * * *")
+	public void updateStatusToES() {
+		searchService.updateStatusToES();
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/search/presentation/SearchController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/search/presentation/SearchController.java
@@ -37,13 +37,14 @@ public class SearchController {
 	public ResponseEntity<StoresInfoSliceRes> searchByES(
 		@RequestParam("x-coordinate") double xCoordinate, @RequestParam("y-coordinate") double yCoordinate,
 		@RequestParam String keyword,
+		@RequestParam(required = false, defaultValue = "distance") String sortBy,
 		@RequestParam(required = false, defaultValue = "0") int page,
 		@RequestParam(required = false, defaultValue = DEFAULT_PAGING_SIZE) int size) {
 
 		page = Math.max(page - 1, 0);
 		PageRequest pageable = PageRequest.of(page, size);
 
-		StoresInfoSliceRes storeResponse = searchService.searchToES(xCoordinate, yCoordinate, keyword, pageable);
+		StoresInfoSliceRes storeResponse = searchService.searchToES(xCoordinate, yCoordinate, keyword, sortBy,pageable);
 
 		return ResponseEntity.ok(storeResponse);
 	}

--- a/src/main/java/com/palpal/dealightbe/domain/search/presentation/SearchController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/search/presentation/SearchController.java
@@ -1,0 +1,51 @@
+package com.palpal.dealightbe.domain.search.presentation;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.palpal.dealightbe.domain.search.application.SearchService;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoresInfoSliceRes;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/search")
+public class SearchController {
+
+	private final SearchService searchService;
+	private static final String DEFAULT_PAGING_SIZE = "10";
+
+	@PostMapping("/bulk")
+	public ResponseEntity<Void> uploadToES() {
+		searchService.uploadToES();
+		return ResponseEntity.noContent().build();
+	}
+
+	@PostMapping("/update")
+	public ResponseEntity<Void> updateStatusToES() {
+		searchService.updateStatusToES();
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping
+	public ResponseEntity<StoresInfoSliceRes> searchByES(
+		@RequestParam("x-coordinate") double xCoordinate, @RequestParam("y-coordinate") double yCoordinate,
+		@RequestParam String keyword,
+		@RequestParam(required = false, defaultValue = "0") int page,
+		@RequestParam(required = false, defaultValue = DEFAULT_PAGING_SIZE) int size) {
+
+		page = Math.max(page - 1, 0);
+		PageRequest pageable = PageRequest.of(page, size);
+
+		StoresInfoSliceRes storeResponse = searchService.searchToES(xCoordinate, yCoordinate, keyword, pageable);
+
+		return ResponseEntity.ok(storeResponse);
+	}
+
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreInfoSliceRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoreInfoSliceRes.java
@@ -19,6 +19,6 @@ public record StoreInfoSliceRes(
 	}
 
 	public static StoreInfoSliceRes from(StoreDocument storeDocument) {
-		return new StoreInfoSliceRes(storeDocument.getId(), storeDocument.getName(), LocalTime.parse(storeDocument.getCloseTime()), storeDocument.getImage());
+		return new StoreInfoSliceRes(Long.parseLong(storeDocument.getId()), storeDocument.getName(), LocalTime.parse(storeDocument.getCloseTime()), storeDocument.getImage());
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoresInfoSliceRes.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/application/dto/response/StoresInfoSliceRes.java
@@ -2,9 +2,7 @@ package com.palpal.dealightbe.domain.store.application.dto.response;
 
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 
 import com.palpal.dealightbe.domain.store.domain.Store;
 import com.palpal.dealightbe.domain.store.domain.StoreDocument;
@@ -22,13 +20,12 @@ public record StoresInfoSliceRes(
 		return new StoresInfoSliceRes(storesInfoSliceRes, storeSlice.hasNext());
 	}
 
-	public static StoresInfoSliceRes of(List<StoreDocument> storeDocuments, Pageable pageable) {
+	public static StoresInfoSliceRes fromDocuments(Slice<StoreDocument> storeDocuments) {
 
 		List<StoreInfoSliceRes> storesInfoSliceRes = storeDocuments.stream()
 			.map(StoreInfoSliceRes::from)
 			.toList();
-		Slice<StoreDocument> storeDocumentSlice = new SliceImpl<>(storeDocuments, pageable, true);
 
-		return new StoresInfoSliceRes(storesInfoSliceRes, storeDocumentSlice.hasNext());
+		return new StoresInfoSliceRes(storesInfoSliceRes, storeDocuments.hasNext());
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/DocumentStatus.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/DocumentStatus.java
@@ -1,0 +1,6 @@
+package com.palpal.dealightbe.domain.store.domain;
+
+public enum DocumentStatus {
+	READY,
+	DONE
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/StoreDocument.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/StoreDocument.java
@@ -1,12 +1,15 @@
 package com.palpal.dealightbe.domain.store.domain;
 
+import java.util.List;
+
 import javax.persistence.Id;
 
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 
-import com.palpal.dealightbe.domain.address.domain.Address;
+import com.palpal.dealightbe.domain.item.domain.ItemDocument;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -24,9 +27,9 @@ import lombok.NoArgsConstructor;
 public class StoreDocument {
 
 	@Id
-	private Long id;
+	private String id;
 
-	private Address address;
+	private GeoPoint location;
 
 	private String name;
 
@@ -38,14 +41,18 @@ public class StoreDocument {
 
 	private String image;
 
-	public static StoreDocument from(Store store) {
+	private List<ItemDocument> items;
+
+	public static StoreDocument from(UpdatedStore updatedStore, Store store) {
 		return StoreDocument.builder()
-			.id(store.getId())
-			.address(store.getAddress())
-			.name(store.getName())
-			.openTime(store.getOpenTime().toString())
-			.closeTime(store.getCloseTime().toString())
-			.image(store.getImage())
+			.id(String.valueOf(updatedStore.getId()))
+			.location(new GeoPoint(updatedStore.getYCoordinate(), updatedStore.getXCoordinate()))
+			.name(updatedStore.getName())
+			.storeStatus(StoreStatus.OPENED)
+			.openTime(updatedStore.getOpenTime().toString())
+			.closeTime(updatedStore.getCloseTime().toString())
+			.image(updatedStore.getImage())
+			.items(ItemDocument.convertToItemDocuments(store.getItems()))
 			.build();
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/StoreDocument.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/StoreDocument.java
@@ -43,16 +43,26 @@ public class StoreDocument {
 
 	private List<ItemDocument> items;
 
-	public static StoreDocument from(UpdatedStore updatedStore, Store store) {
+	public static StoreDocument from(UpdatedStore updatedStore) {
 		return StoreDocument.builder()
 			.id(String.valueOf(updatedStore.getId()))
 			.location(new GeoPoint(updatedStore.getYCoordinate(), updatedStore.getXCoordinate()))
 			.name(updatedStore.getName())
-			.storeStatus(StoreStatus.OPENED)
+			.storeStatus(updatedStore.getStoreStatus())
 			.openTime(updatedStore.getOpenTime().toString())
 			.closeTime(updatedStore.getCloseTime().toString())
 			.image(updatedStore.getImage())
-			.items(ItemDocument.convertToItemDocuments(store.getItems()))
+			.items(ItemDocument.convertToItemDocuments(updatedStore.getItems()))
 			.build();
+	}
+
+	public static List<StoreDocument> convertToStoreDocuments(List<UpdatedStore> stores) {
+		if (stores == null) {
+			return null;
+		}
+
+		return stores.stream()
+			.map(StoreDocument::from)
+			.toList();
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/StoreDocumentRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/StoreDocumentRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface StoreSearchRepository extends ElasticsearchRepository<StoreDocument, Long> {
+public interface StoreDocumentRepository extends ElasticsearchRepository<StoreDocument, Long> {
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/UpdatedStore.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/UpdatedStore.java
@@ -1,13 +1,19 @@
 package com.palpal.dealightbe.domain.store.domain;
 
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import com.palpal.dealightbe.domain.item.domain.UpdatedItem;
 import com.palpal.dealightbe.global.BaseEntity;
 
 import lombok.AccessLevel;
@@ -37,9 +43,15 @@ public class UpdatedStore extends BaseEntity {
 
 	private String image;
 
+	@Enumerated(EnumType.STRING)
+	private DocumentStatus documentStatus = DocumentStatus.READY;
+
+	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "store")
+	private List<UpdatedItem> items = new ArrayList<>();
+
 	@Builder
-	public UpdatedStore(Long id, double xCoordinate, double yCoordinate, String name, StoreStatus storeStatus,
-						LocalTime openTime, LocalTime closeTime, String image) {
+	private UpdatedStore(Long id, double xCoordinate, double yCoordinate, String name, StoreStatus storeStatus,
+						 LocalTime openTime, LocalTime closeTime, String image) {
 		this.id = id;
 		this.xCoordinate = xCoordinate;
 		this.yCoordinate = yCoordinate;
@@ -61,5 +73,21 @@ public class UpdatedStore extends BaseEntity {
 			.closeTime(store.getCloseTime())
 			.image(store.getImage())
 			.build();
+	}
+
+	public void addItem(UpdatedItem item) {
+		this.items.add(item);
+	}
+
+	public void updateDocumentStatus(DocumentStatus status) {
+		this.documentStatus = status;
+	}
+
+	public void updateStoreStatus(StoreStatus storeStatus) {
+		this.storeStatus = storeStatus;
+	}
+
+	public void markAsDone() {
+		this.documentStatus = DocumentStatus.DONE;
 	}
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/UpdatedStore.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/UpdatedStore.java
@@ -1,0 +1,65 @@
+package com.palpal.dealightbe.domain.store.domain;
+
+import java.time.LocalTime;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import com.palpal.dealightbe.global.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "updated_stores")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdatedStore extends BaseEntity {
+
+	@Id
+	private Long id;
+
+	private double xCoordinate;
+	private double yCoordinate;
+	private String name;
+
+	@Enumerated(EnumType.STRING)
+	private StoreStatus storeStatus;
+
+	private LocalTime openTime;
+
+	private LocalTime closeTime;
+
+	private String image;
+
+	@Builder
+	public UpdatedStore(Long id, double xCoordinate, double yCoordinate, String name, StoreStatus storeStatus,
+						LocalTime openTime, LocalTime closeTime, String image) {
+		this.id = id;
+		this.xCoordinate = xCoordinate;
+		this.yCoordinate = yCoordinate;
+		this.name = name;
+		this.storeStatus = storeStatus;
+		this.openTime = openTime;
+		this.closeTime = closeTime;
+		this.image = image;
+	}
+
+	public static UpdatedStore from(Store store) {
+		return UpdatedStore.builder()
+			.id(store.getId())
+			.xCoordinate(store.getAddress().getXCoordinate())
+			.yCoordinate(store.getAddress().getYCoordinate())
+			.name(store.getName())
+			.storeStatus(store.getStoreStatus())
+			.openTime(store.getOpenTime())
+			.closeTime(store.getCloseTime())
+			.image(store.getImage())
+			.build();
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/UpdatedStoreRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/UpdatedStoreRepository.java
@@ -1,0 +1,6 @@
+package com.palpal.dealightbe.domain.store.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UpdatedStoreRepository extends JpaRepository<UpdatedStore, Long> {
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/domain/UpdatedStoreRepository.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/domain/UpdatedStoreRepository.java
@@ -1,6 +1,15 @@
 package com.palpal.dealightbe.domain.store.domain;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UpdatedStoreRepository extends JpaRepository<UpdatedStore, Long> {
+
+	@Query("SELECT us FROM UpdatedStore us WHERE us.documentStatus != 'DONE'")
+	List<UpdatedStore> findAllByDocumentStatusIsReady();
+
+	@Query("SELECT us FROM UpdatedStore us WHERE us.documentStatus != 'READY'")
+	List<UpdatedStore> findAllByDocumentStatusIsDone();
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/infrastructure/StoreSearchRepositoryImpl.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/infrastructure/StoreSearchRepositoryImpl.java
@@ -1,9 +1,14 @@
 package com.palpal.dealightbe.domain.store.infrastructure;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
+import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -13,12 +18,15 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.stereotype.Repository;
 
+import com.palpal.dealightbe.domain.item.domain.ItemDocument;
 import com.palpal.dealightbe.domain.store.domain.StoreDocument;
+import com.palpal.dealightbe.domain.store.domain.StoreStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -38,23 +46,58 @@ public class StoreSearchRepositoryImpl {
 		operations.bulkUpdate(updateQueries, operations.getIndexCoordinatesFor(StoreDocument.class));
 	}
 
+	public void updateStoreItems(String storeId, List<ItemDocument> updatedItems) {
+		List<Map<String, Object>> itemDocuments = updatedItems.stream()
+			.map(item -> operations.getElasticsearchConverter().mapObject(item))
+			.collect(Collectors.toList());
+
+		UpdateQuery updateQuery = UpdateQuery.builder(storeId)
+			.withDocument(Document.from(Collections.singletonMap("items", itemDocuments)))
+			.build();
+
+		operations.update(updateQuery, operations.getIndexCoordinatesFor(StoreDocument.class));
+	}
+
+	public void updateStoreStatus(String storeId, StoreStatus newStatus) {
+		UpdateQuery updateQuery = UpdateQuery.builder(storeId)
+			.withDocument(Document.from(Collections.singletonMap("storeStatus", newStatus)))
+			.build();
+
+		operations.update(updateQuery, operations.getIndexCoordinatesFor(StoreDocument.class));
+	}
+
+	public StoreDocument findById(String id) {
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
+			.withQuery(QueryBuilders.matchQuery("id", id))
+			.build();
+
+		SearchHits<StoreDocument> searchHits = operations.search(searchQuery, StoreDocument.class);
+		if (!searchHits.isEmpty()) {
+			SearchHit<StoreDocument> searchHit = searchHits.getSearchHit(0);
+			return searchHit.getContent();
+		} else {
+			return null;
+		}
+	}
+
 	public Slice<StoreDocument> searchStores(double x, double y, String keyword, Pageable pageable) {
 		NativeSearchQuery searchQuery = buildStoreSearchQuery(x, y, keyword, pageable);
 		SearchHits<StoreDocument> results = operations.search(searchQuery, StoreDocument.class);
 		List<StoreDocument> storeDocuments = results.stream().map(SearchHit::getContent).toList();
-		for (StoreDocument storeDocument : storeDocuments) {
-			System.out.println("storeDocument = " + storeDocument.toString());
-		}
+
 		return toSlice(storeDocuments, pageable);
 	}
 
 	public NativeSearchQuery buildStoreSearchQuery(double x, double y, String keyword, Pageable pageable) {
 		BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
 
-		// 키워드 검색 (업체명 또는 아이템명)
-		MultiMatchQueryBuilder keywordQuery = QueryBuilders.multiMatchQuery(keyword, "name", "items.name")
+		// 키워드 검색 (업체명)
+		MultiMatchQueryBuilder keywordQuery = QueryBuilders.multiMatchQuery(keyword, "name")
 			.operator(Operator.OR)
 			.type(MultiMatchQueryBuilder.Type.BEST_FIELDS);
+
+		// 키워드 검색 (업체가 가진 상품)
+		NestedQueryBuilder itemQuery = QueryBuilders.nestedQuery("items", QueryBuilders.matchQuery("items.name", keyword), ScoreMode.Avg);
 
 		// 거리 필터링
 		QueryBuilder geoQuery = QueryBuilders.geoDistanceQuery("location")
@@ -65,7 +108,8 @@ public class StoreSearchRepositoryImpl {
 		QueryBuilder statusQuery = QueryBuilders.matchQuery("storeStatus", "OPENED");
 
 		// 모든 조건을 must로 추가
-		boolQuery.must(keywordQuery);
+		boolQuery.should(keywordQuery);
+		boolQuery.should(itemQuery);
 		boolQuery.must(geoQuery);
 		boolQuery.must(statusQuery);
 

--- a/src/main/java/com/palpal/dealightbe/domain/store/infrastructure/StoreSearchRepositoryImpl.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/infrastructure/StoreSearchRepositoryImpl.java
@@ -1,0 +1,94 @@
+package com.palpal.dealightbe.domain.store.infrastructure;
+
+import java.util.List;
+
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MultiMatchQueryBuilder;
+import org.elasticsearch.index.query.Operator;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.stereotype.Repository;
+
+import com.palpal.dealightbe.domain.store.domain.StoreDocument;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreSearchRepositoryImpl {
+
+	private final ElasticsearchOperations operations;
+
+	public void bulkInsertOrUpdate(List<StoreDocument> storeDocuments) {
+		List<UpdateQuery> updateQueries = storeDocuments.stream().map(storeDocument ->
+			UpdateQuery.builder(String.valueOf(storeDocument.getId()))
+				.withDocument(operations.getElasticsearchConverter().mapObject(storeDocument))
+				.withDocAsUpsert(true)
+				.build()).toList();
+
+		operations.bulkUpdate(updateQueries, operations.getIndexCoordinatesFor(StoreDocument.class));
+	}
+
+	public Slice<StoreDocument> searchStores(double x, double y, String keyword, Pageable pageable) {
+		NativeSearchQuery searchQuery = buildStoreSearchQuery(x, y, keyword, pageable);
+		SearchHits<StoreDocument> results = operations.search(searchQuery, StoreDocument.class);
+		List<StoreDocument> storeDocuments = results.stream().map(SearchHit::getContent).toList();
+		for (StoreDocument storeDocument : storeDocuments) {
+			System.out.println("storeDocument = " + storeDocument.toString());
+		}
+		return toSlice(storeDocuments, pageable);
+	}
+
+	public NativeSearchQuery buildStoreSearchQuery(double x, double y, String keyword, Pageable pageable) {
+		BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
+
+		// 키워드 검색 (업체명 또는 아이템명)
+		MultiMatchQueryBuilder keywordQuery = QueryBuilders.multiMatchQuery(keyword, "name", "items.name")
+			.operator(Operator.OR)
+			.type(MultiMatchQueryBuilder.Type.BEST_FIELDS);
+
+		// 거리 필터링
+		QueryBuilder geoQuery = QueryBuilders.geoDistanceQuery("location")
+			.point(y, x)
+			.distance("3km");
+
+		// 업체 상태 필터링
+		QueryBuilder statusQuery = QueryBuilders.matchQuery("storeStatus", "OPENED");
+
+		// 모든 조건을 must로 추가
+		boolQuery.must(keywordQuery);
+		boolQuery.must(geoQuery);
+		boolQuery.must(statusQuery);
+
+		// NativeSearchQueryBuilder를 사용하여 쿼리 빌드
+		return new NativeSearchQueryBuilder()
+			.withQuery(boolQuery)
+			.withPageable(pageable)
+			.build();
+	}
+
+	private Slice<StoreDocument> toSlice(List<StoreDocument> contents, Pageable pageable) {
+		boolean hasNext = isContentSizeGreaterThanPageSize(contents, pageable);
+		if (hasNext) {
+			return new SliceImpl<>(subtractLastContent(contents, pageable), pageable, true);
+		}
+		return new SliceImpl<>(contents, pageable, false);
+	}
+
+	private boolean isContentSizeGreaterThanPageSize(List<StoreDocument> contents, Pageable pageable) {
+		return pageable.isPaged() && contents.size() > pageable.getPageSize() - 1;
+	}
+
+	private List<StoreDocument> subtractLastContent(List<StoreDocument> content, Pageable pageable) {
+		return content.subList(0, pageable.getPageSize() - 1);
+	}
+}

--- a/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
@@ -137,4 +137,25 @@ public class StoreController {
 		return ResponseEntity.ok(storeResponse);
 	}
 
+	@PostMapping("/es")
+	public ResponseEntity<Void> uploadToES() {
+		storeService.uploadToES();
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/searchES")
+	public ResponseEntity<StoresInfoSliceRes> searchByES(
+		@RequestParam("x-coordinate") double xCoordinate, @RequestParam("y-coordinate") double yCoordinate,
+		@RequestParam String keyword,
+		@RequestParam(required = false, defaultValue = "0") int page,
+		@RequestParam(required = false, defaultValue = DEFAULT_PAGING_SIZE) int size) {
+
+		page = Math.max(page - 1, 0);
+		PageRequest pageable = PageRequest.of(page, size);
+
+		StoresInfoSliceRes storeResponse = storeService.searchToES(xCoordinate, yCoordinate, keyword, pageable);
+
+		return ResponseEntity.ok(storeResponse);
+	}
+
 }

--- a/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
+++ b/src/main/java/com/palpal/dealightbe/domain/store/presentation/StoreController.java
@@ -136,26 +136,4 @@ public class StoreController {
 
 		return ResponseEntity.ok(storeResponse);
 	}
-
-	@PostMapping("/es")
-	public ResponseEntity<Void> uploadToES() {
-		storeService.uploadToES();
-		return ResponseEntity.noContent().build();
-	}
-
-	@GetMapping("/searchES")
-	public ResponseEntity<StoresInfoSliceRes> searchByES(
-		@RequestParam("x-coordinate") double xCoordinate, @RequestParam("y-coordinate") double yCoordinate,
-		@RequestParam String keyword,
-		@RequestParam(required = false, defaultValue = "0") int page,
-		@RequestParam(required = false, defaultValue = DEFAULT_PAGING_SIZE) int size) {
-
-		page = Math.max(page - 1, 0);
-		PageRequest pageable = PageRequest.of(page, size);
-
-		StoresInfoSliceRes storeResponse = storeService.searchToES(xCoordinate, yCoordinate, keyword, pageable);
-
-		return ResponseEntity.ok(storeResponse);
-	}
-
 }

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 	CLOSED_STORE("ST006", "영업이 종료된 업체입니다."),
 	ALREADY_HAS_STORE("ST007", "이미 업체를 보유하고 있습니다"),
 	UPDATABLE_STORE_NOT_EXIST("ST008", "업데이트 가능한 업체가 없습니다."),
+	NOT_FOUND_UPDATED_STORE("ST009","기본 업체에 대응하는 업데이트 업체가 존재하지 않습니다."),
 
 	//상품
 	INVALID_ITEM_DISCOUNT_PRICE("I001", "상품 할인가는 원가보다 클 수 없습니다."),
@@ -39,6 +40,7 @@ public enum ErrorCode {
 	DUPLICATED_ITEM_NAME("I003", "동일한 이름을 가진 상품이 이미 등록되어 있습니다."),
 	INVALID_ITEM_QUANTITY("I004", "상품 재고가 부족합니다"),
 	STORE_HAS_NO_ITEM("I005", "요청하신 상품은 해당 업체에 등록되지 않은 상품입니다."),
+	UPDATABLE_ITEM_NOT_EXIST("I006","업데이트 가능한 상품이 없습니다."),
 
 	//파일
 	NOT_FOUND_IMAGE("F001", "존재하지 않는 이미지 입니다."),

--- a/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
+++ b/src/main/java/com/palpal/dealightbe/global/error/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 	NOT_FOUND_STATUS("ST005", "존재하지 않는 영업 상태 입니다."),
 	CLOSED_STORE("ST006", "영업이 종료된 업체입니다."),
 	ALREADY_HAS_STORE("ST007", "이미 업체를 보유하고 있습니다"),
+	UPDATABLE_STORE_NOT_EXIST("ST008", "업데이트 가능한 업체가 없습니다."),
 
 	//상품
 	INVALID_ITEM_DISCOUNT_PRICE("I001", "상품 할인가는 원가보다 클 수 없습니다."),

--- a/src/main/resources/elastic/item-mapping.json
+++ b/src/main/resources/elastic/item-mapping.json
@@ -4,10 +4,11 @@
       "type": "text"
     },
     "name": {
-      "type": "text"
+      "type": "text",
+      "analyzer": "nori"
     },
     "storeId": {
-      "type": "long"
+      "type": "text"
     }
   }
 }

--- a/src/main/resources/elastic/item-mapping.json
+++ b/src/main/resources/elastic/item-mapping.json
@@ -9,6 +9,15 @@
     },
     "storeId": {
       "type": "text"
+    },
+    "discountPrice": {
+      "type": "integer"
+    },
+    "originalPrice": {
+      "type": "integer"
+    },
+    "discountRate": {
+      "type": "double"
     }
   }
 }

--- a/src/main/resources/elastic/item-mapping.json
+++ b/src/main/resources/elastic/item-mapping.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "id": {
-      "type": "long"
+      "type": "text"
     },
     "name": {
       "type": "text"

--- a/src/main/resources/elastic/store-mapping.json
+++ b/src/main/resources/elastic/store-mapping.json
@@ -1,18 +1,43 @@
 {
   "properties": {
-    "id": {"type": "long"},
-        "address": {
-          "properties": {
-            "id": {"type": "long"},
-            "name": {"type": "text"},
-            "xCoordinate": {"type": "double"},
-            "yCoordinate": {"type": "double"}
-          }
+    "id": {
+      "type": "text"
+    },
+    "location": {
+      "type": "geo_point"
+    },
+    "name": {
+      "type": "text",
+      "analyzer": "nori"
+    },
+    "storeStatus": {
+      "type": "keyword"
+    },
+    "openTime": {
+      "type": "date",
+      "format": "HH:mm"
+    },
+    "closeTime": {
+      "type": "date",
+      "format": "HH:mm"
+    },
+    "image": {
+      "type": "text"
+    },
+    "items": {
+      "type": "nested",
+      "properties": {
+        "id": {
+          "type": "long"
         },
-    "name": {"type": "text"},
-    "storeStatus": {"type": "keyword"},
-    "openTime": {"type": "date", "format": "HH:mm"},
-    "closeTime": {"type": "date", "format": "HH:mm"},
-    "image": {"type": "text"}
+        "name": {
+          "type": "text",
+          "analyzer": "nori"
+        },
+        "storeId": {
+          "type": "long"
+        }
+      }
+    }
   }
 }

--- a/src/main/resources/elastic/store-mapping.json
+++ b/src/main/resources/elastic/store-mapping.json
@@ -36,6 +36,15 @@
         },
         "storeId": {
           "type": "long"
+        },
+        "discountPrice": {
+          "type": "integer"
+        },
+        "originalPrice": {
+          "type": "integer"
+        },
+        "discountRate": {
+          "type": "double"
         }
       }
     }

--- a/src/main/resources/elastic/store-setting.json
+++ b/src/main/resources/elastic/store-setting.json
@@ -1,8 +1,21 @@
 {
+  "index": {
+    "max_ngram_diff": 5
+  },
   "analysis": {
     "analyzer": {
       "korean": {
         "type": "nori"
+      },
+      "my_ngram_analyzer": {
+        "tokenizer": "my_ngram_tokenizer"
+      }
+    },
+    "tokenizer": {
+      "my_ngram_tokenizer": {
+        "type": "ngram",
+        "min_gram": "2",
+        "max_gram": "5"
       }
     }
   }

--- a/src/main/resources/elastic/store-setting.json
+++ b/src/main/resources/elastic/store-setting.json
@@ -1,21 +1,15 @@
 {
-  "index": {
-    "max_ngram_diff": 5
-  },
   "analysis": {
     "analyzer": {
-      "korean": {
-        "type": "nori"
-      },
-      "my_ngram_analyzer": {
-        "tokenizer": "my_ngram_tokenizer"
+      "nori": {
+        "type": "custom",
+        "tokenizer": "nori_mixed"
       }
     },
     "tokenizer": {
-      "my_ngram_tokenizer": {
-        "type": "ngram",
-        "min_gram": "2",
-        "max_gram": "5"
+      "nori_mixed": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "mixed"
       }
     }
   }

--- a/src/test/java/com/palpal/dealightbe/config/ElasticTestContainer.java
+++ b/src/test/java/com/palpal/dealightbe/config/ElasticTestContainer.java
@@ -8,11 +8,11 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-import com.palpal.dealightbe.domain.item.domain.ItemSearchRepository;
-import com.palpal.dealightbe.domain.store.domain.StoreSearchRepository;
+import com.palpal.dealightbe.domain.item.domain.ItemDocumentRepository;
+import com.palpal.dealightbe.domain.store.domain.StoreDocumentRepository;
 
 @TestConfiguration
-@EnableElasticsearchRepositories(basePackageClasses = {StoreSearchRepository.class, ItemSearchRepository.class})
+@EnableElasticsearchRepositories(basePackageClasses = {StoreDocumentRepository.class, ItemDocumentRepository.class})
 public class ElasticTestContainer extends AbstractElasticsearchConfiguration {
 
 

--- a/src/test/java/com/palpal/dealightbe/domain/item/application/ItemServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/item/application/ItemServiceTest.java
@@ -37,9 +37,13 @@ import com.palpal.dealightbe.domain.item.application.dto.response.ItemRes;
 import com.palpal.dealightbe.domain.item.application.dto.response.ItemsRes;
 import com.palpal.dealightbe.domain.item.domain.Item;
 import com.palpal.dealightbe.domain.item.domain.ItemRepository;
+import com.palpal.dealightbe.domain.item.domain.UpdatedItem;
+import com.palpal.dealightbe.domain.item.domain.UpdatedItemRepository;
 import com.palpal.dealightbe.domain.store.domain.DayOff;
 import com.palpal.dealightbe.domain.store.domain.Store;
 import com.palpal.dealightbe.domain.store.domain.StoreRepository;
+import com.palpal.dealightbe.domain.store.domain.UpdatedStore;
+import com.palpal.dealightbe.domain.store.domain.UpdatedStoreRepository;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
 
@@ -53,6 +57,11 @@ class ItemServiceTest {
 	private ItemRepository itemRepository;
 
 	@Mock
+	private UpdatedItemRepository updatedItemRepository;
+	@Mock
+	private UpdatedStoreRepository updatedStoreRepository;
+
+	@Mock
 	private StoreRepository storeRepository;
 
 	@Mock
@@ -62,6 +71,8 @@ class ItemServiceTest {
 	private Store store2;
 	private Item item;
 	private Item item2;
+	private UpdatedStore updatedStore;
+	private UpdatedItem updatedItem;
 
 	@BeforeEach
 	void setUp() {
@@ -83,6 +94,17 @@ class ItemServiceTest {
 			.address(address)
 			.build();
 
+		updatedStore = UpdatedStore.builder()
+			.id(store.getId())
+			.name(store.getName())
+			.xCoordinate(store.getAddress().getXCoordinate())
+			.yCoordinate(store.getAddress().getYCoordinate())
+			.openTime(store.getOpenTime())
+			.closeTime(store.getCloseTime())
+			.image(store.getImage())
+			.storeStatus(store.getStoreStatus())
+			.build();
+
 		item = Item.builder()
 			.name("떡볶이")
 			.stock(2)
@@ -91,6 +113,13 @@ class ItemServiceTest {
 			.description("기본 떡볶이 입니다.")
 			.image("https://fake-image.com/item1.png")
 			.store(store)
+			.build();
+
+		updatedItem = UpdatedItem.builder()
+			.name(item.getName())
+			.stock(item.getStock())
+			.originalPrice(item.getOriginalPrice())
+			.discountPrice(item.getDiscountPrice())
 			.build();
 
 		Address address2 = Address.builder()
@@ -134,6 +163,10 @@ class ItemServiceTest {
 		when(itemRepository.existsByNameAndStoreId(any(), any())).thenReturn(false);
 		when(itemRepository.save(any(Item.class))).thenReturn(item);
 		when(imageService.store(file)).thenReturn(imageUrl);
+		when(updatedStoreRepository.findById(any()))
+			.thenReturn(Optional.of(updatedStore));
+		when(updatedItemRepository.save(any()))
+			.thenReturn(updatedItem);
 
 		//when
 		ItemRes itemRes = itemService.create(itemReq, providerId, imageUploadReq);

--- a/src/test/java/com/palpal/dealightbe/domain/search/presentation/SearchControllerTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/search/presentation/SearchControllerTest.java
@@ -1,0 +1,105 @@
+package com.palpal.dealightbe.domain.search.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palpal.dealightbe.config.SecurityConfig;
+import com.palpal.dealightbe.domain.search.application.SearchService;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoreInfoSliceRes;
+import com.palpal.dealightbe.domain.store.application.dto.response.StoresInfoSliceRes;
+
+@WebMvcTest(value = SearchController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class,
+	OAuth2ClientAutoConfiguration.class}, excludeFilters = {
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
+@AutoConfigureRestDocs
+class SearchControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@MockBean
+	SearchService searchService;
+
+	@Test
+	@DisplayName("업체 검색")
+	void SearchByDefault() throws Exception {
+
+		//given
+		double xCoordinate = 127.0279372;
+		double yCoordinate = 37.4980136;
+		String keyword = "떡볶이";
+		Long lastId = 5L;
+
+		int size = 5;
+		int page = 0;
+
+		StoreInfoSliceRes store1 = new StoreInfoSliceRes(1L, "천하장사", LocalTime.of(19, 00), "image");
+		StoreInfoSliceRes store2 = new StoreInfoSliceRes(10L, "떡볶이 파는집", LocalTime.of(21, 30), "image");
+		StoresInfoSliceRes storesInfoSliceRes = new StoresInfoSliceRes(
+			List.of(store1, store2), false);
+
+		when(searchService.searchToES(anyDouble(), anyDouble(), any(), any(), any()))
+			.thenReturn(storesInfoSliceRes);
+
+		//when -> then
+		mockMvc.perform(RestDocumentationRequestBuilders.get("/api/search")
+				.contentType(APPLICATION_JSON)
+				.param("x-coordinate", String.valueOf(xCoordinate))
+				.param("y-coordinate", String.valueOf(yCoordinate))
+				.param("keyword", keyword)
+				.param("size", String.valueOf(size))
+				.param("page", String.valueOf(page)))
+			.andExpect(status().isOk())
+			.andDo(print())
+			.andDo(document("search/search-by-option",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				requestParameters(
+					List.of(parameterWithName("x-coordinate").description("경도"),
+						parameterWithName("y-coordinate").description("위도"),
+						parameterWithName("keyword").description("검색어"),
+						parameterWithName("size").description("한 페이지 당 업체 목록 개수"),
+						parameterWithName("page").description("페이지 번호")
+					)),
+				responseFields(
+					fieldWithPath("storeInfoSliceRes[0].storeId").description("조회된 업체 ID"),
+					fieldWithPath("storeInfoSliceRes[0].name").description("조회된 업체 이름"),
+					fieldWithPath("storeInfoSliceRes[0].closeTime").description("조회된 업체 마감 시간"),
+					fieldWithPath("storeInfoSliceRes[0].image").description("조회된 업체 이미지"),
+					fieldWithPath("hasNext").description("추가 결과 여부")
+				)
+			));
+	}
+}

--- a/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/com/palpal/dealightbe/domain/store/application/StoreServiceTest.java
@@ -2,6 +2,7 @@ package com.palpal.dealightbe.domain.store.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +45,8 @@ import com.palpal.dealightbe.domain.store.domain.DayOff;
 import com.palpal.dealightbe.domain.store.domain.Store;
 import com.palpal.dealightbe.domain.store.domain.StoreRepository;
 import com.palpal.dealightbe.domain.store.domain.StoreStatus;
+import com.palpal.dealightbe.domain.store.domain.UpdatedStore;
+import com.palpal.dealightbe.domain.store.domain.UpdatedStoreRepository;
 import com.palpal.dealightbe.global.error.exception.BusinessException;
 import com.palpal.dealightbe.global.error.exception.EntityNotFoundException;
 
@@ -52,6 +55,9 @@ class StoreServiceTest {
 
 	@Mock
 	private StoreRepository storeRepository;
+
+	@Mock
+	private UpdatedStoreRepository updatedStoreRepository;
 
 	@Mock
 	private MemberRepository memberRepository;
@@ -72,6 +78,7 @@ class StoreServiceTest {
 	private Store store;
 	private Store store2;
 	private Store store3;
+	private UpdatedStore updatedStore;
 	private Item item;
 	private Item item2;
 	private Item item3;
@@ -183,6 +190,17 @@ class StoreServiceTest {
 			.store(store3)
 			.build();
 
+		updatedStore = UpdatedStore.builder()
+			.id(store.getId())
+			.name(store.getName())
+			.xCoordinate(store.getAddress().getXCoordinate())
+			.yCoordinate(store.getAddress().getYCoordinate())
+			.openTime(store.getOpenTime())
+			.closeTime(store.getCloseTime())
+			.image(store.getImage())
+			.storeStatus(store.getStoreStatus())
+			.build();
+
 	}
 
 	@DisplayName("업체 등록 성공")
@@ -197,6 +215,8 @@ class StoreServiceTest {
 			.thenReturn(Optional.of(member));
 		when(addressService.register(eq("서울시 강남구"), eq(67.89), eq(293.2323)))
 			.thenReturn(new Address("서울시 강남구", 67.89, 293.2323));
+		when(updatedStoreRepository.save(any()))
+			.thenReturn(updatedStore);
 
 		//when
 		StoreCreateRes storeCreateRes = storeService.register(member.getProviderId(), storeCreateReq);
@@ -371,6 +391,8 @@ class StoreServiceTest {
 			.thenReturn(Optional.of(member));
 		when(storeRepository.findById(store.getId()))
 			.thenReturn(Optional.of(store));
+		when(updatedStoreRepository.findById(any()))
+			.thenReturn(Optional.of(updatedStore));
 
 		//when
 		StoreStatusRes storeStatusRes = storeService.updateStatus(member.getProviderId(), store.getId(), requestStoreStatus);


### PR DESCRIPTION
## 💡 관련 이슈

- close: #267 

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📝 작업 요약

- QueryDSL로 검색하던 시스템을 ElasticSearch를 도입 했습니다.
  - QueryDSL을 사용하는 API 및 코드들은 우선 그대로 두었습니다 (마이그레이션X)  

<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->

## 🔎 작업 상세 설명

- ES에 RDB 데이터를 동기화 시켜주기 위해 Store,Item 엔티티에 대응하는 JPA 엔티티 `UpdatedStore`, `UpdatedItem`생성
  - 유저가 업체(상품)를 등록할 때 UpdatedStore, UpdatedItem도 같이 생성
- ES에 색인을 위한 `StoreDocument`, `ItemDocument` 생성 (UpdatedStore, UpdatedItem을 이용하여 ES 도큐먼트 생성)
- ES에 데이터를 동기화 시켜주기 위한 `uploadToES`/`updateStatusToES` 메서드 및 스케줄러 구현
  -  `uploadToES` : 실제 서비스에 사용되는 RDB 데이터를 ES에도 **등록** - 스케줄러 한 시간 (임의)
  - `updateStatusToES` : 업주가 가게 영업 상태를 바꾸거나, 상품을 등록한 후, 해당 메서드가 스케줄러에 의해 호출 될 때 ES 인덱스에도 업데이트 됩니다. - 스케줄러 30분(임의)

## 🌟 리뷰시 요구 사항

<!-- 리뷰어에게 집중적으로 확인해 줬으면 하는 부분을 적어주세요. (고민 or 더 나은 방향?) -->